### PR TITLE
fix: iOS 에서 getMeterPerDp 사용시 생기는 크래시 수정

### DIFF
--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapControlHandler.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapControlHandler.kt
@@ -49,11 +49,25 @@ internal interface NaverMapControlHandler {
             latLng = call.arguments.asLatLng(),
             onSuccess = result::send,
         )
-        "getMeterPerDp" -> call.arguments.asMap().let {
+        "getMeterPerDp" -> {
+            val arguments = call.arguments?.asMap()
+            val latitude = arguments?.get("latitude")?.asDouble()
+            val zoom = arguments?.get("zoom")?.asDouble()
+            if (latitude != null && zoom != null) {
+                getMeterPerDp(
+                        lat = latitude,
+                        zoom = zoom,
+                        onSuccess = result::send,
+                )
+            } else {
+                getMeterPerDp(result::send)
+            }
+        }
+        "getMeterPerDpAtLatitude" -> call.arguments.asMap().let {
             getMeterPerDp(
-                lat = it["latitude"]?.asDouble(),
-                zoom = it["zoom"]?.asDouble(),
-                onSuccess = result::send,
+                    lat = it["latitude"]!!.asDouble(),
+                    zoom = it["zoom"]!!.asDouble(),
+                    onSuccess = result::send,
             )
         }
         "pickAll" -> call.arguments.asMap().let {
@@ -108,7 +122,9 @@ internal interface NaverMapControlHandler {
 
     fun latLngToScreenLocation(latLng: LatLng, onSuccess: (nPoint: Map<String, Any>) -> Unit)
 
-    fun getMeterPerDp(lat: Double?, zoom: Double?, onSuccess: (meterPerDp: Double) -> Unit)
+    fun getMeterPerDp(onSuccess: (meterPerDp: Double) -> Unit)
+
+    fun getMeterPerDp(lat: Double, zoom: Double, onSuccess: (meterPerDp: Double) -> Unit)
 
     fun pickAll(
         nPoint: NPoint,

--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapController.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapController.kt
@@ -2,11 +2,11 @@ package dev.note11.flutter_naver_map.flutter_naver_map.controller
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.util.Log
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.LocationTrackingMode
 import com.naver.maps.map.NaverMap
+import com.naver.maps.map.Projection
 import com.naver.maps.map.Symbol
 import com.naver.maps.map.indoor.IndoorSelection
 import com.naver.maps.map.overlay.LocationOverlay
@@ -103,19 +103,12 @@ internal class NaverMapController(
         onSuccess(nPoint.toMessageable())
     }
 
-    override fun getMeterPerDp(
-        lat: Double?,
-        zoom: Double?,
-        onSuccess: (meterPerDp: Double) -> Unit,
-    ) {
-        val meterPerDp = if (lat != null || zoom != null) {
-            val willSetLat = lat ?: naverMap.cameraPosition.target.latitude
-            val willSetZoom = zoom ?: naverMap.cameraPosition.zoom
-            naverMap.projection.getMetersPerPixel(willSetLat, willSetZoom)
-        } else {
-            naverMap.projection.metersPerDp
-        }
-        onSuccess(meterPerDp)
+    override fun getMeterPerDp(onSuccess: (meterPerDp: Double) -> Unit) {
+        onSuccess(naverMap.projection.metersPerDp)
+    }
+
+    override fun getMeterPerDp(lat: Double, zoom: Double, onSuccess: (meterPerDp: Double) -> Unit) {
+        onSuccess(Projection.getMetersPerDp(lat, zoom))
     }
 
     override fun pickAll(

--- a/ios/Classes/controller/NaverMapControlHandler.swift
+++ b/ios/Classes/controller/NaverMapControlHandler.swift
@@ -18,6 +18,8 @@ internal protocol NaverMapControlHandler {
     func latLngToScreenLocation(latLng: NMGLatLng, onSuccess: @escaping (_ nPoint: Dictionary<String, Any>) -> Void)
 
     func getMeterPerDp(lat: Double?, zoom: Double?, onSuccess: @escaping (_ meterPerDp: Double) -> Void)
+    
+    func getMeterPerPixelAtLatitude(lat: Double, zoom: Double, onSuccess: @escaping (_ meterPerDp: Double) -> Void)
 
     func pickAll(
             nPoint: NPoint,
@@ -60,7 +62,10 @@ internal extension  NaverMapControlHandler {
         case "latLngToScreenLocation": latLngToScreenLocation(latLng: asLatLng(call.arguments!), onSuccess: result)
         case "getMeterPerDp":
             let d = asDict(call.arguments!)
-            getMeterPerDp(lat: asDouble(d["latitude"]!), zoom: asDouble(d["zoom"]!), onSuccess: result)
+            getMeterPerDp(lat: d["latitude"] as? Double, zoom: d["zoom"] as? Double, onSuccess: result)
+        case "getMeterPerPixelAtLatitude":
+            let d = asDict(call.arguments!)
+            getMeterPerPixelAtLatitude(lat: asDouble(d["latitude"]!), zoom: asDouble(d["zoom"]!), onSuccess: result)
         case "pickAll":
             let d = asDict(call.arguments!)
             pickAll(nPoint: NPoint.fromMessageable(d["point"]!), dpRadius: asDouble(d["radius"]!), onSuccess: result)

--- a/ios/Classes/controller/NaverMapControlHandler.swift
+++ b/ios/Classes/controller/NaverMapControlHandler.swift
@@ -17,7 +17,7 @@ internal protocol NaverMapControlHandler {
 
     func latLngToScreenLocation(latLng: NMGLatLng, onSuccess: @escaping (_ nPoint: Dictionary<String, Any>) -> Void)
 
-    func getMeterPerDp(lat: Double?, zoom: Double?, onSuccess: @escaping (_ meterPerDp: Double) -> Void)
+    func getMeterPerDp(onSuccess: @escaping (_ meterPerDp: Double) -> Void)
     
     func getMeterPerPixelAtLatitude(lat: Double, zoom: Double, onSuccess: @escaping (_ meterPerDp: Double) -> Void)
 
@@ -61,8 +61,16 @@ internal extension  NaverMapControlHandler {
         case "screenLocationToLatLng": screenLocationToLatLng(nPoint: NPoint.fromMessageable(call.arguments!), onSuccess: result)
         case "latLngToScreenLocation": latLngToScreenLocation(latLng: asLatLng(call.arguments!), onSuccess: result)
         case "getMeterPerDp":
-            let d = asDict(call.arguments!)
-            getMeterPerDp(lat: d["latitude"] as? Double, zoom: d["zoom"] as? Double, onSuccess: result)
+            let d = call.arguments as? Dictionary<String, Any?>
+            guard
+                let latitude = d?["latitude"] as? Double,
+                let zoom = d?["zoom"] as? Double
+            else {
+                getMeterPerDp(onSuccess: result)
+                break;
+            }
+
+            getMeterPerPixelAtLatitude(lat: latitude, zoom: zoom, onSuccess: result)
         case "getMeterPerPixelAtLatitude":
             let d = asDict(call.arguments!)
             getMeterPerPixelAtLatitude(lat: asDouble(d["latitude"]!), zoom: asDouble(d["zoom"]!), onSuccess: result)

--- a/ios/Classes/controller/NaverMapControlHandler.swift
+++ b/ios/Classes/controller/NaverMapControlHandler.swift
@@ -19,7 +19,7 @@ internal protocol NaverMapControlHandler {
 
     func getMeterPerDp(onSuccess: @escaping (_ meterPerDp: Double) -> Void)
     
-    func getMeterPerPixelAtLatitude(lat: Double, zoom: Double, onSuccess: @escaping (_ meterPerDp: Double) -> Void)
+    func getMeterPerDpAtLatitude(lat: Double, zoom: Double, onSuccess: @escaping (_ meterPerDp: Double) -> Void)
 
     func pickAll(
             nPoint: NPoint,
@@ -70,10 +70,10 @@ internal extension  NaverMapControlHandler {
                 break;
             }
 
-            getMeterPerPixelAtLatitude(lat: latitude, zoom: zoom, onSuccess: result)
-        case "getMeterPerPixelAtLatitude":
+            getMeterPerDpAtLatitude(lat: latitude, zoom: zoom, onSuccess: result)
+        case "getMeterPerDpAtLatitude":
             let d = asDict(call.arguments!)
-            getMeterPerPixelAtLatitude(lat: asDouble(d["latitude"]!), zoom: asDouble(d["zoom"]!), onSuccess: result)
+            getMeterPerDpAtLatitude(lat: asDouble(d["latitude"]!), zoom: asDouble(d["zoom"]!), onSuccess: result)
         case "pickAll":
             let d = asDict(call.arguments!)
             pickAll(nPoint: NPoint.fromMessageable(d["point"]!), dpRadius: asDouble(d["radius"]!), onSuccess: result)

--- a/ios/Classes/controller/NaverMapControlHandler.swift
+++ b/ios/Classes/controller/NaverMapControlHandler.swift
@@ -19,7 +19,7 @@ internal protocol NaverMapControlHandler {
 
     func getMeterPerDp(onSuccess: @escaping (_ meterPerDp: Double) -> Void)
     
-    func getMeterPerDpAtLatitude(lat: Double, zoom: Double, onSuccess: @escaping (_ meterPerDp: Double) -> Void)
+    func getMeterPerDp(lat: Double, zoom: Double, onSuccess: @escaping (_ meterPerDp: Double) -> Void)
 
     func pickAll(
             nPoint: NPoint,
@@ -70,10 +70,10 @@ internal extension  NaverMapControlHandler {
                 break;
             }
 
-            getMeterPerDpAtLatitude(lat: latitude, zoom: zoom, onSuccess: result)
+            getMeterPerDp(lat: latitude, zoom: zoom, onSuccess: result)
         case "getMeterPerDpAtLatitude":
             let d = asDict(call.arguments!)
-            getMeterPerDpAtLatitude(lat: asDouble(d["latitude"]!), zoom: asDouble(d["zoom"]!), onSuccess: result)
+            getMeterPerDp(lat: asDouble(d["latitude"]!), zoom: asDouble(d["zoom"]!), onSuccess: result)
         case "pickAll":
             let d = asDict(call.arguments!)
             pickAll(nPoint: NPoint.fromMessageable(d["point"]!), dpRadius: asDouble(d["radius"]!), onSuccess: result)

--- a/ios/Classes/controller/NaverMapController.swift
+++ b/ios/Classes/controller/NaverMapController.swift
@@ -68,7 +68,7 @@ internal class NaverMapController: NaverMapControlSender, NaverMapControlHandler
         onSuccess(metersPerDp)
     }
     
-    func getMeterPerPixelAtLatitude(lat: Double, zoom: Double, onSuccess: @escaping (Double) -> Void) {
+    func getMeterPerDpAtLatitude(lat: Double, zoom: Double, onSuccess: @escaping (Double) -> Void) {
         let metersPerPixel: CLLocationDistance = mapView.projection.metersPerPixel(atLatitude: lat, zoom: zoom)
         let metersPerDp = metersPerPixel / UIScreen.main.scale
         onSuccess(metersPerDp)

--- a/ios/Classes/controller/NaverMapController.swift
+++ b/ios/Classes/controller/NaverMapController.swift
@@ -62,15 +62,8 @@ internal class NaverMapController: NaverMapControlSender, NaverMapControlHandler
         onSuccess(NPoint.fromCGPointWithDisplay(point).toMessageable())
     }
 
-    func getMeterPerDp(lat: Double?, zoom: Double?, onSuccess: @escaping (Double) -> ()) {
-        guard let lat = lat, let zoom = zoom else {
-            let metersPerPixel = mapView.projection.metersPerPixel()
-            let metersPerDp = metersPerPixel / UIScreen.main.scale
-            onSuccess(metersPerDp)
-            return
-        }
-
-        let metersPerPixel = mapView.projection.metersPerPixel(atLatitude: lat, zoom: zoom)
+    func getMeterPerDp(onSuccess: @escaping (Double) -> ()) {
+        let metersPerPixel = mapView.projection.metersPerPixel()
         let metersPerDp = metersPerPixel / UIScreen.main.scale
         onSuccess(metersPerDp)
     }

--- a/ios/Classes/controller/NaverMapController.swift
+++ b/ios/Classes/controller/NaverMapController.swift
@@ -63,9 +63,20 @@ internal class NaverMapController: NaverMapControlSender, NaverMapControlHandler
     }
 
     func getMeterPerDp(lat: Double?, zoom: Double?, onSuccess: @escaping (Double) -> ()) {
-        let metersPerPixel: CLLocationDistance = (lat != nil && zoom != nil) ?
-                mapView.projection.metersPerPixel(atLatitude: lat!, zoom: zoom!) :
-                mapView.projection.metersPerPixel()
+        guard let lat = lat, let zoom = zoom else {
+            let metersPerPixel = mapView.projection.metersPerPixel()
+            let metersPerDp = metersPerPixel / UIScreen.main.scale
+            onSuccess(metersPerDp)
+            return
+        }
+
+        let metersPerPixel = mapView.projection.metersPerPixel(atLatitude: lat, zoom: zoom)
+        let metersPerDp = metersPerPixel / UIScreen.main.scale
+        onSuccess(metersPerDp)
+    }
+    
+    func getMeterPerPixelAtLatitude(lat: Double, zoom: Double, onSuccess: @escaping (Double) -> Void) {
+        let metersPerPixel: CLLocationDistance = mapView.projection.metersPerPixel(atLatitude: lat, zoom: zoom)
         let metersPerDp = metersPerPixel / UIScreen.main.scale
         onSuccess(metersPerDp)
     }

--- a/ios/Classes/controller/NaverMapController.swift
+++ b/ios/Classes/controller/NaverMapController.swift
@@ -63,15 +63,11 @@ internal class NaverMapController: NaverMapControlSender, NaverMapControlHandler
     }
 
     func getMeterPerDp(onSuccess: @escaping (Double) -> ()) {
-        let metersPerPixel = mapView.projection.metersPerPixel()
-        let metersPerDp = metersPerPixel / UIScreen.main.scale
-        onSuccess(metersPerDp)
+        onSuccess(mapView.projection.metersPerPixel())
     }
     
     func getMeterPerDp(lat: Double, zoom: Double, onSuccess: @escaping (Double) -> Void) {
-        let metersPerPixel: CLLocationDistance = mapView.projection.metersPerPixel(atLatitude: lat, zoom: zoom)
-        let metersPerDp = metersPerPixel / UIScreen.main.scale
-        onSuccess(metersPerDp)
+        onSuccess(mapView.projection.metersPerPixel(atLatitude: lat, zoom: zoom))
     }
 
     func pickAll(nPoint: NPoint, dpRadius: Double, onSuccess: @escaping (Array<Dictionary<String, Any?>>) -> ()) {

--- a/ios/Classes/controller/NaverMapController.swift
+++ b/ios/Classes/controller/NaverMapController.swift
@@ -68,7 +68,7 @@ internal class NaverMapController: NaverMapControlSender, NaverMapControlHandler
         onSuccess(metersPerDp)
     }
     
-    func getMeterPerDpAtLatitude(lat: Double, zoom: Double, onSuccess: @escaping (Double) -> Void) {
+    func getMeterPerDp(lat: Double, zoom: Double, onSuccess: @escaping (Double) -> Void) {
         let metersPerPixel: CLLocationDistance = mapView.projection.metersPerPixel(atLatitude: lat, zoom: zoom)
         let metersPerDp = metersPerPixel / UIScreen.main.scale
         onSuccess(metersPerDp)

--- a/lib/src/controller/map/controller.dart
+++ b/lib/src/controller/map/controller.dart
@@ -85,6 +85,19 @@ class _NaverMapControllerImpl
   }
 
   @override
+  Future<double> getMeterPerPixelAtLatitude({
+    required double latitude,
+    required double zoom,
+  }) {
+    final messageable = NMessageable.forOnceWithMap({
+      "latitude": latitude,
+      "zoom": zoom,
+    });
+    return invokeMethod("getMeterPerPixelAtLatitude", messageable)
+        .then((value) => value as double);
+  }
+
+  @override
   Future<List<NPickableInfo>> pickAll(NPoint point, {double radius = 0}) async {
     final messageable =
         NMessageable.forOnceWithMap({"point": point, "radius": radius});

--- a/lib/src/controller/map/controller.dart
+++ b/lib/src/controller/map/controller.dart
@@ -85,7 +85,7 @@ class _NaverMapControllerImpl
   }
 
   @override
-  Future<double> getMeterPerPixelAtLatitude({
+  Future<double> getMeterPerDpAtLatitude({
     required double latitude,
     required double zoom,
   }) {
@@ -93,7 +93,7 @@ class _NaverMapControllerImpl
       "latitude": latitude,
       "zoom": zoom,
     });
-    return invokeMethod("getMeterPerPixelAtLatitude", messageable)
+    return invokeMethod("getMeterPerDpAtLatitude", messageable)
         .then((value) => value as double);
   }
 

--- a/lib/src/controller/map/sender.dart
+++ b/lib/src/controller/map/sender.dart
@@ -22,6 +22,11 @@ abstract class _NaverMapControlSender {
 
   Future<double> getMeterPerDp({double? latitude, double? zoom});
 
+  Future<double> getMeterPerPixelAtLatitude({
+    required double latitude,
+    required double zoom,
+  });
+
   Future<List<NPickableInfo>> pickAll(NPoint point, {double radius = 0});
 
   Future<File> takeSnapshot(

--- a/lib/src/controller/map/sender.dart
+++ b/lib/src/controller/map/sender.dart
@@ -22,7 +22,7 @@ abstract class _NaverMapControlSender {
 
   Future<double> getMeterPerDp({double? latitude, double? zoom});
 
-  Future<double> getMeterPerPixelAtLatitude({
+  Future<double> getMeterPerDpAtLatitude({
     required double latitude,
     required double zoom,
   });


### PR DESCRIPTION
fixes #85

# 원인

이슈 제보하신 분이 보내주신 로그를 보니 옵셔널 값을 언래핑하면서 `nil` 이 반환되어 생긴걸로 확인되었습니다.

# 변경사항

* `_NaverMapControlSender.getMeterPerPixelAtLatitude` 함수를 추가했습니다.
  아무래도 간접적인 `getMetersPerDp` 함수에 파라미터들을 nullable 로 두어 간접적으로 오버로딩의 형태를 의도하신 것 같은데 파라미터가 두 개라 하나만 값이 제공될 때 모두 제공될거라는 보장이 없습니다. 따라서 파라미터가 있는 함수, 없는 함수 각각을 명확하게하는게 좋겠다고 생각했습니다. 함수명은 네이버 지도 iOS SDK 의 API reference 의 [metersPerPixelAtLatitude:zoom:](https://navermaps.github.io/ios-map-sdk/reference/Classes/NMFProjection.html#/c:objc(cs)NMFProjection(im)metersPerPixelAtLatitude:zoom:) 에서 따왔습니다.
   * 버전 하위 호환성을 위해 `getMetersPerDp` 의 함수 시그니처를 변경하지 않았습니다. PR 이 반영된다면 파라미터에 `Deprecated` 어노테이션을 다는게 어떨까 싶습니다.
* Flutter 코드 변경에 맞춰 Swift  코드의 플랫폼 메서드 매핑 코드를 변경했습니다.
  * `getMeterPerPixelAtLatitude` 를 추가했습니다.
  * 문제가 됐던 `getMetersPerDp` 의 옵셔널 언래핑을 제거했습니다.
  * 버전 하위 호환성을 위해 `latitude`, `zoom` 파라미터가 모두 전달되었다면 오버로딩된 `NMFProjection.metersPerPixel(atLatitude latitude: Double, zoom: Double)` 함수를 사용하도록했습니다.

# 확인 방법

`example/main.dart` 의 `onMapReady` 함수에 아래와 같이 코드를 첨부하고 실행하면 확인하실 수 있습니다.
```Dart
  void onMapReady(NaverMapController controller) async {
    mapController = controller;

    final position = await controller.getCameraPosition();
    print('[###] zoom: ${position.zoom}'); //[###] zoom: 14.0

    double value = 0.0;

    // 수정 전에는 여기서 에러가 발생합니다.
    value = await controller.getMeterPerDp();
    print('[###] getMetersPerDp: $value'); // [###] getMetersPerDp: 3.786541713960559
    value = await controller.getMeterPerDp(latitude: 72.0);
    print('[###] getMetersPerDp with only latitude: $value'); // [###] getMetersPerDp with only latitude: 3.786541713960559
    value = await controller.getMeterPerDp(zoom: 13.0);
    print('[###] getMetersPerDp with only zoom: $value'); // [###] getMetersPerDp with only zoom: 3.786541713960559

    // 아래 두 요청은 같은 값을 반환합니다.
    value = await controller.getMeterPerDp(latitude: 72.0, zoom: 13.0);
    print('[###] getMetersPerDp with params: $value'); // [###] getMetersPerDp with params: 2.952542592454751
    value =
        await controller.getMeterPerDpAtLatitude(latitude: 72.0, zoom: 13.0);
    print('[###] getMeterPerDpAtLatitude: $value'); // [###] getMeterPerDpAtLatitude: 2.952542592454751
  }
```