### PR TITLE
Fix: #154

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 - [Example] Add Example controller.pickAll & takeSnapshot.
 
 ### Fix
-- [Android] Fix black screen caused by flutter 3.16.0~ & android 6.0~9.0 (SDK 23~28) (issue: [#135](https://github.com/note11g/flutter_naver_map/issues/135), PR: [#153](https://github.com/note11g/flutter_naver_map/pull/153))
-- [Android] Fix MapWidget ignore navigator stack issue android 6.0~13.0 (SDK 23~33) (issue: [#56](https://github.com/note11g/flutter_naver_map/issues/56), Temp Fix PR: [#151](https://github.com/note11g/flutter_naver_map/pull/151))
+- [All Platform] Fix: InfoWindow.onMarker not attached successfully (issue: [#154](https://github.com/note11g/flutter_naver_map/issues/154), PR: [#156](https://github.com/note11g/flutter_naver_map/pull/156))
+- [Android] Fix: black screen caused by flutter 3.16.0~ & android 6.0~9.0 (SDK 23~28) (issue: [#135](https://github.com/note11g/flutter_naver_map/issues/135), PR: [#153](https://github.com/note11g/flutter_naver_map/pull/153))
+- [Android] Fix: MapWidget ignore navigator stack issue android 6.0~13.0 (SDK 23~33) (issue: [#56](https://github.com/note11g/flutter_naver_map/issues/56), Temp Fix PR: [#151](https://github.com/note11g/flutter_naver_map/pull/151))
 
 ## 1.1.0+1
 - Update Readme & Apply Dart formatting

--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/overlay/OverlayController.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/overlay/OverlayController.kt
@@ -254,6 +254,7 @@ internal class OverlayController(
         success: (Any?) -> Unit,
     ) {
         val nInfoWindow = NInfoWindow.fromMessageable(rawInfoWindow, context = context)
+            .apply { setCommonProperties(rawInfoWindow.asMap()) }
         val infoWindow = saveOverlayWithAddable(creator = nInfoWindow)
 
         val align = rawAlign.asAlign()

--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/converter/AddableOverlay.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/converter/AddableOverlay.kt
@@ -26,7 +26,7 @@ internal abstract class AddableOverlay<T : Overlay> {
 
     private lateinit var commonProperties: Map<String, Any>
 
-    private fun setCommonProperties(rawArgs: Map<String, Any>) {
+    fun setCommonProperties(rawArgs: Map<String, Any>) {
         commonProperties = rawArgs.filter { OverlayHandler.allPropertyNames.contains(it.key) }
     }
 

--- a/ios/Classes/controller/overlay/OverlayController.swift
+++ b/ios/Classes/controller/overlay/OverlayController.swift
@@ -233,7 +233,8 @@ internal class OverlayController: OverlaySender, OverlayHandler, ArrowheadPathOv
     }
 
     func openInfoWindow(_ marker: NMFMarker, rawInfoWindow: Any, rawAlign: Any, success: (Any?) -> ()) {
-        let nInfoWindow = NInfoWindow.fromMessageable(rawInfoWindow)
+        var nInfoWindow = NInfoWindow.fromMessageable(rawInfoWindow)
+        nInfoWindow.setCommonProperties(rawArgs: asDict(rawInfoWindow))
         let infoWindow = saveOverlayWithAddable(creator: nInfoWindow) as! NMFInfoWindow
 
         let align = try! asAlign(rawAlign)


### PR DESCRIPTION
## Summary
Fix: InfoWindow.onMarker not attached successfully (issue: #154)

## Test

dd28a64b9c9e4b10f588fec0c66ce14cc11ed4c6 커밋에서 테스트 케이스 시도시 실패 확인.
719b989fbe4067ae2d462ce6872a8ff764943414, 47fa80bf94ee15a93decabe8740ea7f391a81771 커밋에서 수정. **테스트 케이스 통과 확인.**

### 실행 환경

Android: Pixel 4 API 33 Emulator, iOS: iPhone 15 pro iOS 17.0 Simulator

### 테스트 방법

NOverlay들에서 공통적으로 사용되는 프로퍼티 중 하나인, `minZoom`을 활용하였음.
이 프로퍼티가 정상적으로 적용되면, 줌 레벨에 따라 보여지거나, 보여지지 않게 된다.
이때, `NaverMapController.pickAll` 메서드를 활용하여 이를 검증할 수 있다.

https://github.com/note11g/flutter_naver_map/blob/317dcdb481125b758764a10285656893e9bfca58/example/integration_test/overlay_test.dart#L139-L174