### PR TITLE
Add: `NaverMap.onMapLoaded` event

### DIFF
--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapControlSender.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapControlSender.kt
@@ -17,4 +17,6 @@ internal interface NaverMapControlSender {
     fun onCameraIdle()
 
     fun onSelectedIndoorChanged(selectedIndoor: IndoorSelection?)
+
+    fun onMapLoaded()
 }

--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapController.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapController.kt
@@ -243,6 +243,10 @@ internal class NaverMapController(
         channel.invokeMethod("onSelectedIndoorChanged", selectedIndoor?.toMessageable())
     }
 
+    override fun onMapLoaded() {
+        channel.invokeMethod("onMapLoaded", null)
+    }
+
     /*
       --- remove ---
     */

--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/view/NaverMapView.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/view/NaverMapView.kt
@@ -89,6 +89,7 @@ internal class NaverMapView(
             addOnCameraChangeListener(naverMapControlSender::onCameraChange)
             addOnCameraIdleListener(naverMapControlSender::onCameraIdle)
             addOnIndoorSelectionChangeListener(naverMapControlSender::onSelectedIndoorChanged)
+            addOnLoadListener(naverMapControlSender::onMapLoaded)
         }
     }
 
@@ -100,6 +101,7 @@ internal class NaverMapView(
                 removeOnCameraChangeListener(naverMapControlSender::onCameraChange)
                 removeOnCameraIdleListener(naverMapControlSender::onCameraIdle)
                 removeOnIndoorSelectionChangeListener(naverMapControlSender::onSelectedIndoorChanged)
+                removeOnLoadListener(naverMapControlSender::onMapLoaded)
             }
         }
     }

--- a/ios/Classes/SwiftFlutterNaverMapPlugin.swift
+++ b/ios/Classes/SwiftFlutterNaverMapPlugin.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import NMapsMap
 
 public class SwiftFlutterNaverMapPlugin: NSObject, FlutterPlugin {
     private static var registrar: FlutterPluginRegistrar!
@@ -8,6 +9,7 @@ public class SwiftFlutterNaverMapPlugin: NSObject, FlutterPlugin {
         self.registrar = registrar
 
         initializeSdkChannel(binaryMessenger: registrar.messenger())
+        initializeCacheCount()
 
         let naverMapFactory = NaverMapFactory(messenger: registrar.messenger())
         registrar.register(naverMapFactory,
@@ -18,6 +20,14 @@ public class SwiftFlutterNaverMapPlugin: NSObject, FlutterPlugin {
     private static func initializeSdkChannel(binaryMessenger: FlutterBinaryMessenger) {
         let sdkChannel = FlutterMethodChannel(name: SwiftFlutterNaverMapPlugin.SDK_CHANNEL_NAME, binaryMessenger: binaryMessenger)
         _ = SdkInitializer(channel: sdkChannel)
+    }
+    
+    private static func initializeCacheCount() {
+        lastCacheCount = NMFOfflineStorage.shared.countOfBytesCompleted
+        // todo : Temporary load fix.
+//        NMFOfflineStorage.shared.resetDatabase(completionHandler: {_ in
+//            print("NMFOflineStorage(Cache) reseted!")
+//        })
     }
 
     private static let SDK_CHANNEL_NAME = "flutter_naver_map_sdk"

--- a/ios/Classes/SwiftFlutterNaverMapPlugin.swift
+++ b/ios/Classes/SwiftFlutterNaverMapPlugin.swift
@@ -24,10 +24,6 @@ public class SwiftFlutterNaverMapPlugin: NSObject, FlutterPlugin {
     
     private static func initializeCacheCount() {
         lastCacheCount = NMFOfflineStorage.shared.countOfBytesCompleted
-        // todo : Temporary load fix.
-//        NMFOfflineStorage.shared.resetDatabase(completionHandler: {_ in
-//            print("NMFOflineStorage(Cache) reseted!")
-//        })
     }
 
     private static let SDK_CHANNEL_NAME = "flutter_naver_map_sdk"

--- a/ios/Classes/controller/NaverMapControlSender.swift
+++ b/ios/Classes/controller/NaverMapControlSender.swift
@@ -12,4 +12,6 @@ internal protocol NaverMapControlSender : AnyObject {
     func onCameraIdle()
 
     func onSelectedIndoorChanged(selectedIndoor: NMFIndoorSelection?)
+    
+    func onMapLoaded()
 }

--- a/ios/Classes/controller/NaverMapController.swift
+++ b/ios/Classes/controller/NaverMapController.swift
@@ -189,6 +189,10 @@ internal class NaverMapController: NaverMapControlSender, NaverMapControlHandler
     func onSelectedIndoorChanged(selectedIndoor: NMFIndoorSelection?) {
         channel.invokeMethod("onSelectedIndoorChanged", arguments: selectedIndoor?.toMessageable())
     }
+    
+    func onMapLoaded() {
+        channel.invokeMethod("onMapLoaded", arguments: nil)
+    }
 
     /*
       --- deinit ---

--- a/ios/Classes/view/NaverMapView.swift
+++ b/ios/Classes/view/NaverMapView.swift
@@ -19,6 +19,7 @@ internal class NaverMapView: NSObject, FlutterPlatformView {
     private func onMapReady() {
         setMapTapListener()
         naverMapControlSender.onMapReady()
+        eventDelegate.checkNowShownMapIsCached()
     }
 
     private func setMapTapListener() {

--- a/ios/Classes/view/NaverMapViewEventDelegate.swift
+++ b/ios/Classes/view/NaverMapViewEventDelegate.swift
@@ -1,13 +1,12 @@
 import NMapsMap
 
-internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMFMapViewCameraDelegate, NMFIndoorSelectionDelegate, NMFOfflineStorageDelegate, NMFTileCoverHelperDelegate {
+internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMFMapViewCameraDelegate, NMFIndoorSelectionDelegate, NMFOfflineStorageDelegate {
     private weak var sender: NaverMapControlSender?
 
     private let initializeConsumeSymbolTapEvents: Bool
     private var animated: Bool = true
     private let offlineStorageHelper: NMFOfflineStorage = NMFOfflineStorage()
     private var isLoaded: Bool = false
-    private var tileCoverHelper: NMFTileCoverHelper?
 
     init(sender: NaverMapControlSender, initializeConsumeSymbolTapEvents: Bool) {
         self.sender = sender
@@ -49,13 +48,13 @@ internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMF
         mapView.addCameraDelegate(delegate: self)
         mapView.addIndoorSelectionDelegate(delegate: self)
         
-        let sharedOfflineStorage = NMFOfflineStorage.shared
-        
         offlineStorageHelper.delegate = self
-//        sharedOfflineStorage.delegate = self
         
-        if tileCoverHelper == nil { tileCoverHelper = NMFTileCoverHelper(mapView) }
-        tileCoverHelper!.delegate = self
+        let nowCount = NMFOfflineStorage.shared.countOfBytesCompleted
+        
+        print("cacheCheck(dif:\(nowCount - lastCacheCount):: last:\(lastCacheCount), now:\(nowCount)")
+//        if nowCount == lastCacheCount { onMapLoaded(desc: "maybe") } // cached.
+        lastCacheCount = nowCount
     }
 
     func unregisterDelegates(mapView: NMFMapView) {
@@ -63,26 +62,17 @@ internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMF
         mapView.removeCameraDelegate(delegate: self)
         mapView.removeIndoorSelectionDelegate(delegate: self)
         offlineStorageHelper.delegate = nil
-        tileCoverHelper?.delegate = nil
-    }
-    
-    func onTileChanged(_ addedTileIds: [NSNumber]?, removedTileIds: [NSNumber]?) {
-//        if addedTileIds?.isEmpty == false {
-//            let diff = LoadedTiles.shared.addTilesAndCheckUnLoadedTiles(addedTileIds!, mapHashCode: self.hashValue)
-//            print("diff: \(diff)")
-//            let alreadyLoaded = diff.isEmpty
-//            if !isLoaded && alreadyLoaded { onMapLoaded(desc: "maybe") }
-//        }
-//        if removedTileIds?.isEmpty == false {
-//            LoadedTiles.shared.removeTiles(removedTileIds!)
-//        }
     }
     
     func offlineStorage(_ storage: NMFOfflineStorage, urlForResourceOf kind: NMFResourceKind, with url: URL) -> URL {
         onMapLoaded(desc: "sure")
-//        LoadedTiles.shared.mapLoaded(self.hashValue)
-    
-        offlineStorageHelper.delegate = nil
+        print("offlineStorageSaved: \(url.absoluteString)")
+        lastCacheCount = NMFOfflineStorage.shared.countOfBytesCompleted
+        
+        if kind == .tile {
+            offlineStorageHelper.delegate = nil
+        }
+//        offlineStorageHelper.delegate = nil
         return url
     }
     
@@ -95,77 +85,4 @@ internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMF
         }
     }
 }
-
-//private class LoadedTiles {
-//    static func removeAllStorageCache(onDone: @escaping () -> Void) {
-//        let sharedOfflineStorage = NMFOfflineStorage.shared
-//        let isFirst = sharedOfflineStorage.packs == nil
-//        if isFirst {
-//            sharedOfflineStorage.flushCache { _ in
-//                sharedOfflineStorage.resetDatabase(completionHandler: {_ in
-//                    onDone()
-//                })
-//            }
-//        }
-//    }
-//    
-//    static let shared = LoadedTiles() // already lazy. see https://developer.apple.com/swift/blog/?id=7
-//    
-//    private init() {}
-//    
-//    // todo : load를 Map으로 변경하여, 로드 여부까지 표시할 수 있음 (첫 로드 시점에 true로 변경)
-//    
-//    // 1. tileId를 통해 tile이 로드되었는지 정보가 필요한 것이다.
-//    // 2. 로드되었는지는, map이 로드되었는지 여부와 상관관계를 가진다.
-//    
-//    typealias TileId = NSNumber
-//    typealias MapHashCode = Int
-//    
-//    // unsafe for thread
-//    private var _tiles: Dictionary<TileId, MapHashCode> = [:] // key: TileId, value: mapHashCode
-//    private var _loadedHashes: Set<MapHashCode> = [] // MapHashCode
-//    var loadedTiles: Array<TileId> {
-//        [TileId](_tiles.filter({ _loadedHashes.contains($1) }).keys)
-//    }
-//    
-//    var isFirstLoad: Bool { _tiles.isEmpty }
-//    
-//    func mapLoaded(_ mapHashCode: MapHashCode) {
-//        print("** mapLoaded ** : \(mapHashCode)")
-//        _loadedHashes.insert(mapHashCode)
-//        print("+++nowLoadedTiles: \(String(describing: loadedTiles))")
-//    }
-//    
-//    // 새로 로드될 타일에 대해서 반환됩니다. 없다면, 빈배열.
-//    func addTilesAndCheckUnLoadedTiles(_ tiles: [TileId], mapHashCode: MapHashCode) -> [TileId] {
-//        var newLoadTiles: [TileId] = []
-//
-//        for tile in tiles {
-//            let alreadyLoaded = loadedTiles.contains(tile)
-//            if !alreadyLoaded {
-//                _tiles[tile] = mapHashCode
-//                newLoadTiles.append(tile)
-//            }
-//        }
-//
-//        return newLoadTiles
-//    }
-//    
-//    func removeTiles(_ tileIdList: [TileId]) {
-//        var depentMaps: Set<MapHashCode> = []
-//        
-//        for tileId in tileIdList {
-//            let mapHashCode = _tiles[tileId]
-//            _tiles[tileId] = nil
-//            if let mapHashCode = mapHashCode {
-//                depentMaps.insert(mapHashCode)
-//            }
-//        }
-//        
-//        for depentMap in depentMaps {
-//            if !_tiles.contains(where: { _, map in depentMap == map }) {
-//                _loadedHashes.remove(depentMap)
-//            }
-//        }
-//    }
-//}
+var lastCacheCount: UInt64 = 0

--- a/ios/Classes/view/NaverMapViewEventDelegate.swift
+++ b/ios/Classes/view/NaverMapViewEventDelegate.swift
@@ -1,10 +1,13 @@
 import NMapsMap
 
-internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMFMapViewCameraDelegate, NMFIndoorSelectionDelegate {
+internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMFMapViewCameraDelegate, NMFIndoorSelectionDelegate, NMFOfflineStorageDelegate, NMFTileCoverHelperDelegate {
     private weak var sender: NaverMapControlSender?
 
     private let initializeConsumeSymbolTapEvents: Bool
     private var animated: Bool = true
+    private let offlineStorageHelper: NMFOfflineStorage = NMFOfflineStorage()
+    private var isLoaded: Bool = false
+    private var tileCoverHelper: NMFTileCoverHelper?
 
     init(sender: NaverMapControlSender, initializeConsumeSymbolTapEvents: Bool) {
         self.sender = sender
@@ -45,11 +48,124 @@ internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMF
         mapView.touchDelegate = self
         mapView.addCameraDelegate(delegate: self)
         mapView.addIndoorSelectionDelegate(delegate: self)
+        
+        let sharedOfflineStorage = NMFOfflineStorage.shared
+        
+        offlineStorageHelper.delegate = self
+//        sharedOfflineStorage.delegate = self
+        
+        if tileCoverHelper == nil { tileCoverHelper = NMFTileCoverHelper(mapView) }
+        tileCoverHelper!.delegate = self
     }
 
     func unregisterDelegates(mapView: NMFMapView) {
         mapView.touchDelegate = nil
         mapView.removeCameraDelegate(delegate: self)
         mapView.removeIndoorSelectionDelegate(delegate: self)
+        offlineStorageHelper.delegate = nil
+        tileCoverHelper?.delegate = nil
+    }
+    
+    func onTileChanged(_ addedTileIds: [NSNumber]?, removedTileIds: [NSNumber]?) {
+//        if addedTileIds?.isEmpty == false {
+//            let diff = LoadedTiles.shared.addTilesAndCheckUnLoadedTiles(addedTileIds!, mapHashCode: self.hashValue)
+//            print("diff: \(diff)")
+//            let alreadyLoaded = diff.isEmpty
+//            if !isLoaded && alreadyLoaded { onMapLoaded(desc: "maybe") }
+//        }
+//        if removedTileIds?.isEmpty == false {
+//            LoadedTiles.shared.removeTiles(removedTileIds!)
+//        }
+    }
+    
+    func offlineStorage(_ storage: NMFOfflineStorage, urlForResourceOf kind: NMFResourceKind, with url: URL) -> URL {
+        onMapLoaded(desc: "sure")
+//        LoadedTiles.shared.mapLoaded(self.hashValue)
+    
+        offlineStorageHelper.delegate = nil
+        return url
+    }
+    
+    private func onMapLoaded(desc: String) {
+        if isLoaded { return }
+        do {
+            isLoaded = true
+            sender?.onMapLoaded()
+            print("[swift, \(desc)] onMapLoaded! : \(Date().timeIntervalSince1970)")
+        }
     }
 }
+
+//private class LoadedTiles {
+//    static func removeAllStorageCache(onDone: @escaping () -> Void) {
+//        let sharedOfflineStorage = NMFOfflineStorage.shared
+//        let isFirst = sharedOfflineStorage.packs == nil
+//        if isFirst {
+//            sharedOfflineStorage.flushCache { _ in
+//                sharedOfflineStorage.resetDatabase(completionHandler: {_ in
+//                    onDone()
+//                })
+//            }
+//        }
+//    }
+//    
+//    static let shared = LoadedTiles() // already lazy. see https://developer.apple.com/swift/blog/?id=7
+//    
+//    private init() {}
+//    
+//    // todo : load를 Map으로 변경하여, 로드 여부까지 표시할 수 있음 (첫 로드 시점에 true로 변경)
+//    
+//    // 1. tileId를 통해 tile이 로드되었는지 정보가 필요한 것이다.
+//    // 2. 로드되었는지는, map이 로드되었는지 여부와 상관관계를 가진다.
+//    
+//    typealias TileId = NSNumber
+//    typealias MapHashCode = Int
+//    
+//    // unsafe for thread
+//    private var _tiles: Dictionary<TileId, MapHashCode> = [:] // key: TileId, value: mapHashCode
+//    private var _loadedHashes: Set<MapHashCode> = [] // MapHashCode
+//    var loadedTiles: Array<TileId> {
+//        [TileId](_tiles.filter({ _loadedHashes.contains($1) }).keys)
+//    }
+//    
+//    var isFirstLoad: Bool { _tiles.isEmpty }
+//    
+//    func mapLoaded(_ mapHashCode: MapHashCode) {
+//        print("** mapLoaded ** : \(mapHashCode)")
+//        _loadedHashes.insert(mapHashCode)
+//        print("+++nowLoadedTiles: \(String(describing: loadedTiles))")
+//    }
+//    
+//    // 새로 로드될 타일에 대해서 반환됩니다. 없다면, 빈배열.
+//    func addTilesAndCheckUnLoadedTiles(_ tiles: [TileId], mapHashCode: MapHashCode) -> [TileId] {
+//        var newLoadTiles: [TileId] = []
+//
+//        for tile in tiles {
+//            let alreadyLoaded = loadedTiles.contains(tile)
+//            if !alreadyLoaded {
+//                _tiles[tile] = mapHashCode
+//                newLoadTiles.append(tile)
+//            }
+//        }
+//
+//        return newLoadTiles
+//    }
+//    
+//    func removeTiles(_ tileIdList: [TileId]) {
+//        var depentMaps: Set<MapHashCode> = []
+//        
+//        for tileId in tileIdList {
+//            let mapHashCode = _tiles[tileId]
+//            _tiles[tileId] = nil
+//            if let mapHashCode = mapHashCode {
+//                depentMaps.insert(mapHashCode)
+//            }
+//        }
+//        
+//        for depentMap in depentMaps {
+//            if !_tiles.contains(where: { _, map in depentMap == map }) {
+//                _loadedHashes.remove(depentMap)
+//            }
+//        }
+//    }
+//}

--- a/ios/Classes/view/NaverMapViewEventDelegate.swift
+++ b/ios/Classes/view/NaverMapViewEventDelegate.swift
@@ -49,12 +49,6 @@ internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMF
         mapView.addIndoorSelectionDelegate(delegate: self)
         
         offlineStorageHelper.delegate = self
-        
-        let nowCount = NMFOfflineStorage.shared.countOfBytesCompleted
-        
-        print("cacheCheck(dif:\(nowCount - lastCacheCount):: last:\(lastCacheCount), now:\(nowCount)")
-//        if nowCount == lastCacheCount { onMapLoaded(desc: "maybe") } // cached.
-        lastCacheCount = nowCount
     }
 
     func unregisterDelegates(mapView: NMFMapView) {
@@ -64,6 +58,18 @@ internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMF
         offlineStorageHelper.delegate = nil
     }
     
+    func checkNowShownMapIsCached() {
+        let nowCacheCount = NMFOfflineStorage.shared.countOfBytesCompleted
+        
+        print("cacheCheck(dif:\(nowCacheCount != lastCacheCount):: last:\(lastCacheCount), now:\(nowCacheCount)")
+        do {
+            if nowCacheCount == lastCacheCount { // cached. register timing is too ealry. not sended platform messages.
+                onMapLoaded(desc: "maybe")
+            }
+        }
+        lastCacheCount = nowCacheCount
+    }
+    
     func offlineStorage(_ storage: NMFOfflineStorage, urlForResourceOf kind: NMFResourceKind, with url: URL) -> URL {
         onMapLoaded(desc: "sure")
         print("offlineStorageSaved: \(url.absoluteString)")
@@ -71,9 +77,10 @@ internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMF
         
         if kind == .tile {
             offlineStorageHelper.delegate = nil
+            return url
+        } else {
+            return URL(string: "https://map.pstatic.net/nrs/api/")! // URL Cache Failed.
         }
-//        offlineStorageHelper.delegate = nil
-        return url
     }
     
     private func onMapLoaded(desc: String) {

--- a/lib/src/controller/map/handler.dart
+++ b/lib/src/controller/map/handler.dart
@@ -13,6 +13,8 @@ mixin _NaverMapControlHandler {
 
   void onSelectedIndoorChanged(NSelectedIndoor? selectedIndoor);
 
+  void onMapLoaded();
+
   Future<dynamic> handle(MethodCall call) async {
     switch (call.method) {
       case "onMapReady":
@@ -43,6 +45,9 @@ mixin _NaverMapControlHandler {
             ? NSelectedIndoor._fromMessageable(call.arguments)
             : null;
         onSelectedIndoorChanged(selectedIndoor);
+        break;
+      case "onMapLoaded":
+        onMapLoaded();
         break;
     }
   }

--- a/lib/src/widget/map_widget.dart
+++ b/lib/src/widget/map_widget.dart
@@ -14,6 +14,7 @@ class NaverMap extends StatefulWidget {
       onCameraChange;
   final void Function()? onCameraIdle;
   final void Function(NSelectedIndoor? selectedIndoor)? onSelectedIndoorChanged;
+  final void Function()? onMapLoaded;
 
   const NaverMap({
     super.key,
@@ -25,6 +26,7 @@ class NaverMap extends StatefulWidget {
     this.onCameraChange,
     this.onCameraIdle,
     this.onSelectedIndoorChanged,
+    this.onMapLoaded,
   });
 
   @override
@@ -105,6 +107,9 @@ class _NaverMapState extends State<NaverMap>
 
   @override
   void onCameraIdle() => widget.onCameraIdle?.call();
+
+  @override
+  void onMapLoaded() => widget.onMapLoaded?.call();
 
   @override
   void dispose() {


### PR DESCRIPTION
## Background
지도의 로드가 완료 되었을 때, 감지할 수 있는 방법이 존재하지 않음.
이는 유저의 UX를 해칠 수 있는 가능성이 있음.

## How it works

android의 경우, [NaverMap.OnLoadListener](https://navermaps.github.io/android-map-sdk/reference/com/naver/maps/map/NaverMap.OnLoadListener.html) callback을 사용함.

iOS의 경우, 해당 기능을 별도로 제공하지 않고 있음.

따라서, 여러가지 방식을 시도해보았으나 용량이 아주 작은(0.5\~2.5kb) 메타데이터 http request의 캐싱이 LocalStorage에 이루어질 때를 활용하는 방법이 가장 안정적이었음. 이때, 4\~8회 가량 캐시되면 해당 요청 자체를 요청하지 않는 현상이 발생하여, 강제로 해당 메타데이터만 캐싱하지 않도록 처리함. 이 메타데이터 request의 크기는 매우 작기때문에, 별도의 로드 성능 저하는 체감되지 않음.

이외에도 전체 캐시 데이터의 초기화나, 지도 타일(부분적 타일)을 활용하여 캐시맵을 만드는 등의 방안을 검토하였으나, 로드 성능 저하 혹은 캐시히트가 맞지 않는 문제로(내부적으로 캐싱을 처리하는 부분이 더 있는 것으로 추정됨) 정확한 로드 타이밍 계산이 어려워짐에 따라, 활용하기 힘들 것으로 판단함.

## How to Use (now)

1. 해당 브랜치 소스를 활용하기 위해, `pubspec.yaml`에 라이브러리를 다음과 같이 추가합니다.

```yaml
flutter_naver_map:
  git:
    url: https://github.com/note11g/flutter_naver_map.git
    ref: onMapLoaded
```

2. `NaverMap`위젯의 파라미터로 `onMapLoaded` 콜백을 전달합니다. 이때, 콜백의 타입은 `dynamic Function()` 입니다.

```dart
NaverMap(
  onMapLoaded: () {
    print("onMapLoaded!!");
  },
)
```

## Test

android는 정상 작동 확인하였으며, navermap android sdk에서 지원하는 기능이므로 추가 테스트가 필수적이지는 않습니다.

iOS도 정상 작동 확인하였으나, 별도로 우회하여 구현하였으므로 테스트가 필요합니다.
따라서, 일부 테스트 케이스를 자동화한 integration test를 1/14 오전에 커밋하겠습니다.
해당 테스트가 다섯 분 이상의 기기에서 통과하면, 해당 PR을 Merge하겠습니다.

integration test로는 모든 케이스를 커버할 수 없기에, 별도로 아래 케이스들을 테스트해주시면 감사드리겠습니다.

**Test Cases**
1. 앱 첫 실행시 작동여부
2. 앱 다회차 실행시 작동여부 (NaverMapViewOptions.initialCameraPosition이 **다를 때**)
3. 앱 다회차 실행시 작동여부 (NaverMapViewOptions.initialCameraPosition이 **같을 때**)
4. `NaverMapViewOptions.initialCameraPosition`이 **같을 때**, 지도위젯을 최소 6회 이상 새로 로드하였을 때 모두 작동하는지 여부.
5. `NaverMapViewOptions.initialCameraPosition`이 **다를 때**, 지도위젯을 최소 6회 이상 새로 로드하였을 때 모두 작동하는지 여부. 
(지도 타일이 겹치지 않는 범위에서 로드해야 합니다. `zoom=14` 기준으로, 위도/경도는 0.1 이상 차이나면 겹쳐지지 않는 것으로 보여짐)

다른 카메라 위치 테스트를 위한 배열 코드 공유드립니다.
```dart
static const testCameraPositions = [
    NCameraPosition(target: NLatLng(37.55, 126.914), zoom: 15),
    NCameraPosition(target: NLatLng(37.5, 127.028), zoom: 16),
    NCameraPosition(target: NLatLng(37.5, 127.035), zoom: 17),
    NCameraPosition(target: NLatLng(37.45, 126.944), zoom: 10),
    NCameraPosition(target: NLatLng(36.487, 127.26), zoom: 14),
    NCameraPosition(target: NLatLng(35.16, 129.058), zoom: 13),
    NCameraPosition(target: NLatLng(33.49, 126.496), zoom: 16),
];

// 랜덤 포지션 얻기 함수 예제. 순차적으로 가져가도 상관 없습니다.
NCameraPosition get randomCameraPosition =>
      testCameraPositions[Random().nextInt(testCameraPositions.length)];
```