### PR TITLE
1.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.1
+### Improve
+- [All Platform] Add / Improve APIs
+  - Add: Add `NCameraPosition.copyWith` method.
+### Fix
+- [Android] Fix PlatformView Issue for Android 13~14(>=API 33) (issue: [#189](https://github.com/note11g/flutter_naver_map/issues/189))
+- [iOS] Fix `NOverlayImage.fromAssetImage` Size issue. (issue: [#91](https://github.com/note11g/flutter_naver_map/issues/91), PR: [#185](https://github.com/note11g/flutter_naver_map/pull/185))
+
 ## 1.2.0
 
 ### Improve
@@ -55,7 +63,7 @@
 - [All Platform] Fix `NAddableOverlay` continues to reference the `OverlayController` of the map even after being removed (issue: [#127](https://github.com/note11g/flutter_naver_map/issues/127), PR: [#146](https://github.com/note11g/flutter_naver_map/pull/146))
 - [All Platform] Fix common overlay options were not applied before overlay was added to the map (issue: [#115](https://github.com/note11g/flutter_naver_map/issues/115), PR: [#144](https://github.com/note11g/flutter_naver_map/pull/144))
 - [All Platform] Fix `NLocationOverlay.setSubIcon(null)` Cause NPE (issue: [#142](https://github.com/note11g/flutter_naver_map/issues/142), PR: [#143](https://github.com/note11g/flutter_naver_map/pull/143))
-- [iOS] Fix NOverlayImage Size issue. (issue: [#91](https://github.com/note11g/flutter_naver_map/issues/91), [#130](https://github.com/note11g/flutter_naver_map/issues/130), PR: [#138](https://github.com/note11g/flutter_naver_map/pull/138), [#126](https://github.com/note11g/flutter_naver_map/pull/126))
+- [iOS] Fix `NOverlayImage` Size issue. (issue: [#91](https://github.com/note11g/flutter_naver_map/issues/91), [#130](https://github.com/note11g/flutter_naver_map/issues/130), PR: [#138](https://github.com/note11g/flutter_naver_map/pull/138), [#126](https://github.com/note11g/flutter_naver_map/pull/126))
 - [iOS] Fix the Camera Bearing issue. (issue: [#101](https://github.com/note11g/flutter_naver_map/issues/101), PR: [#110](https://github.com/note11g/flutter_naver_map/pull/110))
 
 ## 1.0.2

--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/view/NaverMapView.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/view/NaverMapView.kt
@@ -33,7 +33,7 @@ internal class NaverMapView(
     private lateinit var naverMapControlSender: NaverMapControlSender
     private val mapView =
         MapView(flutterProvidedContext, naverMapViewOptions.naverMapOptions.apply {
-            useTextureView(Build.VERSION.SDK_INT <= 29)
+            useTextureView(Build.VERSION.SDK_INT !in 30..32)
         }).apply {
             setTempMethodCallHandler()
             getMapAsync { naverMap ->

--- a/lib/src/type/map/camera/camera_position.dart
+++ b/lib/src/type/map/camera/camera_position.dart
@@ -21,6 +21,19 @@ class NCameraPosition with NMessageableWithMap {
     );
   }
 
+  NCameraPosition copyWith({
+    NLatLng? target,
+    double? zoom,
+    double? tilt,
+    double? bearing,
+  }) =>
+      NCameraPosition(
+        target: target ?? this.target,
+        zoom: zoom ?? this.zoom,
+        bearing: bearing ?? this.bearing,
+        tilt: tilt ?? this.tilt,
+      );
+
   @override
   String toString() => "$runtimeType: ${toNPayload().map}";
 

--- a/lib/src/type/map/overlay/overlay_image.dart
+++ b/lib/src/type/map/overlay/overlay_image.dart
@@ -47,8 +47,7 @@ class NOverlayImage with NMessageableWithMap {
       });
 
   @override
-  String toString() =>
-      "NOverlayImage{from: ${_mode.toExplainString()}}";
+  String toString() => "NOverlayImage{from: ${_mode.toExplainString()}}";
 
   @override
   bool operator ==(Object other) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_naver_map
 description: Naver Map plugin for Flutter, which provides map service of Korea.
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/note11g/flutter_naver_map
 documentation: https://note11.dev/flutter_naver_map
 

--- a/test/camera_update_test.dart
+++ b/test/camera_update_test.dart
@@ -11,7 +11,7 @@ void main() {
         tilt: tilt1, zoom: zoom1, bearing: bearing1, target: target1);
 
     expect(cu1.toString(),
-        "CameraUpdate: {target: {lat: ${target1.latitude}, lng: ${target1.longitude}}, zoom: $zoom1, tilt: $tilt1, bearing: $bearing1, animation: easing, duration: 800, sign: withParams}");
+        "NCameraUpdate: {target: {lat: ${target1.latitude}, lng: ${target1.longitude}}, zoom: $zoom1, tilt: $tilt1, bearing: $bearing1, animation: easing, duration: 800, sign: withParams}");
 
     const target2 = NLatLng(37.5662, 126.97);
     const zoom2 = 17.0;
@@ -21,7 +21,7 @@ void main() {
         tiltBy: tilt2, zoomBy: zoom2, bearingBy: bearing2, target: target2);
 
     expect(cu2.toString(),
-        "CameraUpdate: {target: {lat: ${target2.latitude}, lng: ${target2.longitude}}, zoomBy: $zoom2, tiltBy: $tilt2, bearingBy: $bearing2, animation: easing, duration: 800, sign: withParams}");
+        "NCameraUpdate: {target: {lat: ${target2.latitude}, lng: ${target2.longitude}}, zoomBy: $zoom2, tiltBy: $tilt2, bearingBy: $bearing2, animation: easing, duration: 800, sign: withParams}");
   });
 
   test("cameraUpdateAssertionTest", () {


### PR DESCRIPTION
**pub.dev에서 애널리시스 이슈가 발생할 수 있습니다. 이는 main channel을 기준으로 pub.dev의 테스트가 돌아가지만, 3.20에서 이전버전과 호환 불가능한 API argument 변경이 있기 때문에 컴파일 이슈가 발생하는 것입니다. 다음은 관련 이슈입니다. (#182)

## 1.2.1
### Improve
- [All Platform] Add / Improve APIs
  - Add: Add `NCameraPosition.copyWith` method.
### Fix
- [Android] Fix PlatformView Issue for Android 13~14(>=API 33) (issue: [#189](https://github.com/note11g/flutter_naver_map/issues/189))
- [iOS] Fix `NOverlayImage.fromAssetImage` Size issue. (issue: [#91](https://github.com/note11g/flutter_naver_map/issues/91), PR: [#185](https://github.com/note11g/flutter_naver_map/pull/185)(Merge Approved with Review))
