### PR TITLE
Fix: support All Iterable Types in `NPayload` (fix #217)

### DIFF
--- a/lib/src/messaging/messageable.dart
+++ b/lib/src/messaging/messageable.dart
@@ -51,33 +51,35 @@ class NPayload {
     if (value.isDefaultType) return value;
 
     assert(value is NMessageable ||
-        value is List ||
+        value is Iterable ||
         value is Locale ||
         value is EdgeInsets ||
         value is Size ||
         value is Color);
 
-    if (value is NMessageable) return value.payload;
-    if (value is List) {
-      return value.map((e) => convertToMessageable(e!)).toList();
+    switch (value) {
+      case NMessageable():
+        return value.payload;
+      case Iterable():
+        return value.map((e) => convertToMessageable(e!)).toList();
+      default:
+        final result = _tryConvertFlutterUITypes(value);
+        if (result == null) {
+          throw UnsupportedError(
+              "Unsupported Messaging Type: ${value.runtimeType}");
+        }
+        return result;
     }
-    return _convertFlutterTypes(value);
   }
 
-  static dynamic _convertFlutterTypes(Object value) {
-    if (value is Color) return value.value;
-
-    late final NMessageable nMessageable;
-
-    if (value is Locale) {
-      nMessageable = NLocale.fromLocale(value);
-    } else if (value is EdgeInsets) {
-      nMessageable = NEdgeInsets.fromEdgeInsets(value);
-    } else if (value is Size) {
-      nMessageable = NSize.fromSize(value);
-    }
-
-    return nMessageable.payload;
+  static dynamic _tryConvertFlutterUITypes(Object value) {
+    return switch (value) {
+      Locale() => NLocale.fromLocale(value).payload,
+      EdgeInsets() => NEdgeInsets.fromEdgeInsets(value).payload,
+      Size() => NSize.fromSize(value).payload,
+      Color() => value.value,
+      _ => null,
+    };
   }
 
   @override

--- a/test/json_test.dart
+++ b/test/json_test.dart
@@ -2,7 +2,7 @@ import "package:flutter_naver_map/flutter_naver_map.dart";
 import "package:flutter_test/flutter_test.dart";
 
 void main() {
-  test("type test", () {
+  test("option type test", () {
     const option = NaverMapViewOptions(activeLayerGroups: [
       NLayerGroup.transit,
       NLayerGroup.bicycle,

--- a/test/messageable_test.dart
+++ b/test/messageable_test.dart
@@ -1,0 +1,17 @@
+import "package:flutter_naver_map/src/messaging/messaging.dart";
+import "package:flutter_test/flutter_test.dart";
+
+void main() {
+  test("Iterable in payload serialization test (#217)", () {
+    final rawMap = {
+      "list": [1, 2, 3],
+      "set": {"a", "b", "c"},
+    };
+    expect(rawMap["list"].runtimeType.toString(), "List<int>");
+    expect(rawMap["set"].runtimeType.toString(), "_Set<String>");
+
+    final payload = NPayload.make(rawMap);
+    expect(payload.map["list"].runtimeType.toString(), "List<dynamic>");
+    expect(payload.map["set"].runtimeType.toString(), "List<dynamic>");
+  });
+}


### PR DESCRIPTION
Fix: support All Iterable Types in `NPayload`

Related Issue: #217 