### PR TITLE
[Add API] `NRange` (정수 두 개 사이의 범위를 하나의 객체로 나타내기)

### DIFF
--- a/lib/flutter_naver_map.dart
+++ b/lib/flutter_naver_map.dart
@@ -61,6 +61,8 @@ part 'src/type/base/point.dart';
 
 part 'src/type/base/size.dart';
 
+part 'src/type/base/range.dart';
+
 part 'src/type/map/camera/camera_position.dart';
 
 part 'src/type/map/camera/camera_update.dart';

--- a/lib/src/type/base/range.dart
+++ b/lib/src/type/base/range.dart
@@ -24,7 +24,7 @@ class NRange with NMessageableWithMap {
     this.max, {
     this.includeMin = true,
     this.includeMax = true,
-  });
+  }) : assert(min == null || max == null || min <= max);
 
   /// 값이 범위 내에 있는지 확인합니다.
   bool contains(num value) {

--- a/lib/src/type/base/range.dart
+++ b/lib/src/type/base/range.dart
@@ -108,3 +108,8 @@ class NRange with NMessageableWithMap {
         "inMax": includeMax,
       });
 }
+
+class NInclusiveRange extends NRange {
+  const NInclusiveRange(super.min, super.max)
+      : super(includeMin: true, includeMax: true);
+}

--- a/lib/src/type/base/range.dart
+++ b/lib/src/type/base/range.dart
@@ -13,7 +13,7 @@ part of "../../../flutter_naver_map.dart";
 /// ( range <= 7 ) => `NMapRange(null, 7)`
 ///
 @immutable
-class NRange {
+class NRange with NMessageableWithMap {
   final double? min;
   final double? max;
   final bool includeMin;
@@ -98,9 +98,13 @@ class NRange {
         includeMin: newIncludeMin, includeMax: newIncludeMax);
   }
 
-/* todo: support invert?
-      - NMapRange(3, 5).invert() || NMapRange.invert(3, 5)
-         => [range < 3 || 5 < range] */
-
   static const mapZoomRange = NRange(0, 21);
+
+  @override
+  NPayload toNPayload() => NPayload.make({
+        "min": min,
+        "max": max,
+        "inMin": includeMin,
+        "inMax": includeMax,
+      });
 }

--- a/lib/src/type/base/range.dart
+++ b/lib/src/type/base/range.dart
@@ -1,0 +1,106 @@
+part of "../../../flutter_naver_map.dart";
+
+/// 네이버 맵에서 특정 범위를 나타내는 객체입니다.
+///
+/// 주로, 줌 레벨의 범위를 나타낼 때 사용됩니다.
+///
+/// e.g.
+///
+/// ( 8 < range <= 17 ) => `NMapRange(8, 17, includeMin: false)`
+///
+/// ( 0 < range < 21 ) => `NMapRange(0, 21, includeMin: false, includeMax: false)`
+///
+/// ( range <= 7 ) => `NMapRange(null, 7)`
+///
+@immutable
+class NRange {
+  final double? min;
+  final double? max;
+  final bool includeMin;
+  final bool includeMax;
+
+  const NRange(
+    this.min,
+    this.max, {
+    this.includeMin = true,
+    this.includeMax = true,
+  });
+
+  /// 값이 범위 내에 있는지 확인합니다.
+  bool contains(num value) {
+    if (min == null && max == null) return true;
+
+    final lowerBound = min == null
+        ? true
+        : includeMin
+            ? value >= min!
+            : value > min!;
+    final upperBound = max == null
+        ? true
+        : includeMax
+            ? value <= max!
+            : value < max!;
+
+    return lowerBound && upperBound;
+  }
+
+  /// 다른 범위 객체가 현재 범위 내에 완전히 포함되는지 확인합니다.
+  bool containsRange(NRange other) {
+    final bool minCompare;
+    if (min == null) {
+      minCompare = true;
+    } else if (other.min == null) {
+      minCompare = false;
+    } else {
+      minCompare = includeMin ? other.min! >= min! : other.min! > min!;
+    }
+
+    final bool maxCompare;
+    if (max == null) {
+      maxCompare = true;
+    } else if (other.max == null) {
+      maxCompare = false;
+    } else {
+      maxCompare = includeMax ? other.max! <= max! : other.max! < max!;
+    }
+
+    return minCompare && maxCompare;
+  }
+
+  NRange? intersection(NRange other) {
+    final bool isDisjoint =
+        (min != null && other.max != null && min! > other.max!) ||
+            (min != null &&
+                other.max != null &&
+                min! == other.max! &&
+                !(includeMin && other.includeMax)) ||
+            (max != null && other.min != null && max! < other.min!) ||
+            (max != null &&
+                other.min != null &&
+                max! == other.min! &&
+                !(includeMax && other.includeMin));
+
+    if (isDisjoint) {
+      return null;
+    }
+
+    final double? newMin = (min == null || other.min == null)
+        ? min ?? other.min
+        : math.max(min!, other.min!);
+    final double? newMax = (max == null || other.max == null)
+        ? max ?? other.max
+        : math.min(max!, other.max!);
+
+    final bool newIncludeMin = newMin == min ? includeMin : other.includeMin;
+    final bool newIncludeMax = newMax == max ? includeMax : other.includeMax;
+
+    return NRange(newMin, newMax,
+        includeMin: newIncludeMin, includeMax: newIncludeMax);
+  }
+
+/* todo: support invert?
+      - NMapRange(3, 5).invert() || NMapRange.invert(3, 5)
+         => [range < 3 || 5 < range] */
+
+  static const mapZoomRange = NRange(0, 21);
+}


### PR DESCRIPTION
초안을 게시합니다.

## `NRange`

_정수 두 개 사이의 범위를 하나의 객체로 나타내기_

### Description

주로 줌 레벨의 범위 표현에 사용될 예정입니다.

예제는 다음과 같습니다.

e.g. 12 ≤ \[마커가 보일 줌 범위] < 18

## Implementation (Constructor)
```dart
const NRange(
    double min,
    double max, { 
    bool includeMin = true,
    bool includeMax = true,
  });
```
_min, max값은 통상적으로 해당 값을 포함하므로, includeMin/Max의 기본값은 true입니다._

## As-is
```dart
marker
  .setMinZoom(12)
  .setMaxZoom(18)
  .setIsMinZoomInclusive(true)
  .setIsMaxZoomInclusive(false);
```

## To-be
```dart
marker.setShownZoomLevel(const NRange(12, 18, includeMax: false));
```

todo
- [ ] Support Non-exclude min/max type of NRange (will use on `NaverMapViewOptions.minZoom/maxZoom`)
- [ ] Code Review