### PR TITLE
1.2.2-flutter3.22 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.2-flutter3.22
+- support flutter 3.22 (if you using under 3.22, using `flutter_naver_map 1.2.2`)
+
 ## 1.2.2
 ### Fix
 - [Android] Fix Only One Start Frame from Android TextureView Doesn't Copied to Flutter Platform View(TLHC) (issue: [#195](https://github.com/note11g/flutter_naver_map/issues/195), PR: [#212](https://github.com/note11g/flutter_naver_map/pull/212))

--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@
 
 <a href="https://note11.dev/flutter_naver_map" alt="go to documentation page"><img src="https://github.com/note11g/flutter_naver_map/assets/67783062/f3c9c433-0a45-4d35-95b6-3baf753878e0"/></a><a href="https://github.com/note11g/flutter_naver_map/issues" alt="go to github issue page"><img src="https://github.com/note11g/flutter_naver_map/assets/67783062/89efa17d-bf96-413d-b910-0f38e9c36c3f"/></a><a href="https://github.com/users/note11g/projects/2/views/2" alt="go to issue tracker page"><img src="https://github.com/note11g/flutter_naver_map/assets/67783062/4bb00306-85e6-4e4d-9329-6129d6f344f6"/></a>
 
+## API Reference
+
+현재는 문서보다, API Reference가 권장됩니다. 문서는 out-dated된 내용이 있으니, 참고하세요.
+
+[API Reference 바로가기](https://pub.dev/documentation/flutter_naver_map/latest/)
+
+## Flutter 3.22 Support
+- 현재 최신버전 (<flutter 3.22): `1.2.2`
+- Flutter 3.22 대응 최신 버전: `1.2.2-flutter3.22`
+
+3.22 이전 버전과 호환되지 않는 API가 존재하여, 다음과 같이 사용하시면 됩니다.
+1.3.0에서 역시 동일하게 두가지로 나뉘어 출시됩니다.
+
 ## Version Up Guide
 
 `1.2.0`부터는 Flutter SDK 최소 지원 버전이 `3.19`로 변경되었습니다. 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -89,11 +89,12 @@ packages:
   flutter_bottom_drawer:
     dependency: "direct main"
     description:
-      name: flutter_bottom_drawer
-      sha256: "3d832e1819210144e9a0ce30a574acecda1a2ad6a61fcf6898f4fb1a82024693"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0"
+      path: "."
+      ref: "migrate_3.20"
+      resolved-ref: "8fb4bbc865ca52b2ee60754f1aa83a7df1771578"
+      url: "https://github.com/note11g/flutter_bottom_drawer.git"
+    source: git
+    version: "0.1.1"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -167,34 +168,34 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -231,10 +232,10 @@ packages:
     dependency: "direct dev"
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
@@ -428,10 +429,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -452,10 +453,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   webdriver:
     dependency: transitive
     description:
@@ -481,5 +482,5 @@ packages:
     source: hosted
     version: "1.0.3"
 sdks:
-  dart: ">=3.2.1 <4.0.0"
-  flutter: ">=3.19.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.22.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -118,7 +118,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.2-flutter3.22"
   flutter_styled_toast:
     dependency: "direct main"
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,7 +15,10 @@ dependencies:
   flutter_naver_map:
     path: ../
 
-  flutter_bottom_drawer: 0.1.0
+  flutter_bottom_drawer:
+    git:
+      url: https://github.com/note11g/flutter_bottom_drawer.git
+      ref: migrate_3.20
   permission_handler: ^11.3.0
   flutter_styled_toast: 2.2.1
   pull_to_refresh_flutter3: 2.0.2

--- a/lib/src/util/widget_to_image.dart
+++ b/lib/src/util/widget_to_image.dart
@@ -40,7 +40,8 @@ class WidgetToImageUtil {
     final renderView = RenderView(
         view: view,
         configuration: ViewConfiguration(
-            size: size, devicePixelRatio: view.devicePixelRatio),
+            logicalConstraints: BoxConstraints.tight(size),
+            devicePixelRatio: view.devicePixelRatio),
         child: renderPositionedBox);
 
     final pipelineOwner = PipelineOwner()..rootNode = renderView;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: flutter_naver_map
 description: Naver Map plugin for Flutter, which provides map service of Korea.
-version: 1.2.2
+version: 1.2.2-flutter3.22
 homepage: https://github.com/note11g/flutter_naver_map
 documentation: https://note11.dev/flutter_naver_map
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: ">=3.19.0"
+  flutter: ">=3.22.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
flutter 3.22 버전을 대응하기 위한 긴급 업데이트입니다.
다른 신규 수정사항은 1.3.0 버전에서 제공됩니다.

tested on `Channel stable, 3.22.0, on macOS 14.4.1 23E224 darwin-arm64, locale ko-KR`

resolves #182, resolves #231, resolves #233, resolves #234