### PR TITLE
1.2.3+1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.3+1
+- [iOS] Update podspec file
+- [Chore] Update README.MD
+
 ## 1.2.3
 - [All Platform] **change naver map sdk version to 3.18.0(Android) & 3.18.1(iOS) + No additional features (feature add will be in 1.3.0)**
 - [All Platform] **change minimum flutter sdk version to 3.22.0**

--- a/README.md
+++ b/README.md
@@ -22,6 +22,29 @@
 
 ## Version Up Guide
 
+- **`1.2.3` 이상 버전으로 업데이트 하시려면, 다음 과정을 한번 수행해주셔야 합니다.**
+    ```shell
+    cd ios # 프로젝트의 ios 폴더로 이동
+    pod update NMapsMap
+  
+    cd .. # 프로젝트 루트로 이동 (optional)
+  
+    cd android # 프로젝트의 android 폴더로 이동
+    ./gradlew clean
+    ./gradlew --refresh-dependencies
+    ```
+  
+    이 명령어를 프로젝트 루트에서 실행하면, 한번에 수행하실 수 있습니다.
+    Mac
+    ```shell
+    (cd ios && pod update NMapsMap) && (cd android && ./gradlew clean && ./gradlew --refresh-dependencies)
+    ```
+    Windows
+    ```shell
+    cd android && gradlew.bat clean && gradlew.bat --refresh-dependencies
+    ```
+- 
+
 - `1.2.3`부터는 Flutter SDK 최소 지원 버전이 `3.22.0`으로 변경되었습니다. 
 
 - `1.1.0 이하` -> `1.1.1 이상`으로 업그레이드 할 경우, 해당 코드를 다음과 같이 지워주세요.<br>(편의상 주석처리로 표시해두었지만, 그냥 지워주세요)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - Flutter (1.0.0)
-  - flutter_naver_map (1.3.0):
+  - flutter_naver_map (1.2.3):
     - Flutter
-    - NMapsMap (= 3.18.0)
+    - NMapsMap (= 3.18.1)
   - integration_test (0.0.1):
     - Flutter
-  - NMapsGeometry (1.0.1)
-  - NMapsMap (3.18.0):
+  - NMapsGeometry (1.0.2)
+  - NMapsMap (3.18.1):
     - NMapsGeometry
   - path_provider_foundation (0.0.1):
     - Flutter
@@ -40,13 +40,13 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_naver_map: f9661aa502b7cf014e286339662b904dda925143
-  integration_test: 13825b8a9334a850581300559b8839134b124670
-  NMapsGeometry: 53c573ead66466681cf123f99f698dc8071a4b83
-  NMapsMap: 36dc18a1f5f315121b33fccd2398c7a702bf0fc8
+  flutter_naver_map: 9b36cee8e83421f40782af8a4e7afbdf63ee5f92
+  integration_test: ce0a3ffa1de96d1a89ca0ac26fca7ea18a749ef4
+  NMapsGeometry: 4e02554fa9880ef02ed96b075dc84355d6352479
+  NMapsMap: e879088eeee2d1e3b97f0a609076e1824dce2cad
   path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
   permission_handler_apple: 036b856153a2b1f61f21030ff725f3e6fece2b78
 
 PODFILE CHECKSUM: 865bfa77219454a712543ad6494f6458c48be43e
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.15.2

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -119,7 +119,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.2.3+1"
   flutter_styled_toast:
     dependency: "direct main"
     description:
@@ -168,34 +168,34 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -232,10 +232,10 @@ packages:
     dependency: "direct dev"
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
@@ -429,10 +429,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -453,10 +453,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   webdriver:
     dependency: transitive
     description:
@@ -482,5 +482,5 @@ packages:
     source: hosted
     version: "1.0.3"
 sdks:
-  dart: ">=3.2.1 <4.0.0"
-  flutter: ">=3.19.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.22.0"

--- a/ios/flutter_naver_map.podspec
+++ b/ios/flutter_naver_map.podspec
@@ -4,7 +4,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'flutter_naver_map'
-  s.version          = '1.3.0'
+  s.version          = '1.2.3'
   s.summary          = 'flutter naver map plugin'
   s.description      = <<-DESC
 flutter naver map plugin
@@ -15,7 +15,7 @@ flutter naver map plugin
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'NMapsMap','3.18.0'
+  s.dependency 'NMapsMap','3.18.1'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_naver_map
 description: Naver Map plugin for Flutter, which provides map service of Korea.
-version: 1.2.3
+version: 1.2.3+1
 homepage: https://github.com/note11g/flutter_naver_map
 documentation: https://note11.dev/flutter_naver_map
 


### PR DESCRIPTION
1.2.3 버전의 수정 버전입니다. 기존 버전은 pub에서 내렸습니다. 
iOS 플랫폼에서의 잘못된 버전 참조 및 리드미 수정하였습니다.

tested on `Channel stable, 3.22.2, on macOS 14.5 23F79 darwin-arm64, locale ko-KR`


## 1.2.3+1
- [iOS] Update podspec file
- [Chore] Update README.MD
