### PR TITLE
Fix Memory Leak caused by Clustering controller (fix #275)

### DIFF
--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapController.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapController.kt
@@ -313,6 +313,7 @@ internal class NaverMapController(
 
     fun remove() {
         channel.setMethodCallHandler(null)
+        clusteringController.dispose()
         overlayController.remove()
     }
 }

--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/clustering/ClusteringController.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/clustering/ClusteringController.kt
@@ -45,13 +45,15 @@ internal class ClusteringController(
 
         cacheScreenDistance(options.mergeStrategy.willMergedScreenDistance)
 
-        val builder = ComplexBuilder<NClusterableMarkerInfo>().applyEnableZoomLevel(options.enableZoomRange)
-            .maxScreenDistance(options.mergeStrategy.maxMergeableScreenDistance)
-            .animationDuration(options.animationDuration.toInt())
+        val builder =
+            ComplexBuilder<NClusterableMarkerInfo>().applyEnableZoomLevel(options.enableZoomRange)
+                .maxScreenDistance(options.mergeStrategy.maxMergeableScreenDistance)
+                .animationDuration(options.animationDuration.toInt())
 //            .distanceStrategy(::distanceStrategy)
-            .thresholdStrategy(::thresholdStrategy).tagMergeStrategy(::tagMergeStrategy)
-            .clusterMarkerUpdater(::onClusterMarkerUpdate).leafMarkerUpdater(::onClusterableMarkerUpdate)
-            .markerManager(this).minIndexingZoom(0).maxIndexingZoom(0) // 해도 되는지 확인 필요
+                .thresholdStrategy(::thresholdStrategy).tagMergeStrategy(::tagMergeStrategy)
+                .clusterMarkerUpdater(::onClusterMarkerUpdate)
+                .leafMarkerUpdater(::onClusterableMarkerUpdate)
+                .markerManager(this).minIndexingZoom(0).maxIndexingZoom(0) // 해도 되는지 확인 필요
 
         updateAfterAnimationInvalidateDelay(options.animationDuration)
 
@@ -63,7 +65,8 @@ internal class ClusteringController(
 
     private fun cacheScreenDistance(willMergedScreenDistance: Map<NRange<Int>, Double>) {
         for (i in MINIMUM_ZOOM..MAXIMUM_ZOOM) { // 0 ~ 21
-            val firstMatchedDistance = willMergedScreenDistance.entries.firstOrNull { it.key.isInRange(i) }?.value
+            val firstMatchedDistance =
+                willMergedScreenDistance.entries.firstOrNull { it.key.isInRange(i) }?.value
             mergedScreenDistanceCacheArray[i] = firstMatchedDistance ?: DEFAULT_SCREEN_DISTANCE
         }
     }
@@ -91,7 +94,8 @@ internal class ClusteringController(
     }
 
     fun addClusterableMarkerAll(markers: List<NClusterableMarker>) {
-        val markersWithTag: Map<NClusterableMarkerInfo, NClusterableMarker> = markers.associateBy { it.info }
+        val markersWithTag: Map<NClusterableMarkerInfo, NClusterableMarker> =
+            markers.associateBy { it.info }
         clusterer.addAll(markersWithTag)
         updateClusterer()
         clusterableMarkers.putAll(markersWithTag)
@@ -259,7 +263,10 @@ internal class ClusteringController(
 //                val nMarker = data.wrappedMarker
 //                overlayController.saveOverlayWithAddable(nMarker, marker)
 //            }
-            is NClusterInfo -> overlayController.saveOverlay(marker, data.markerInfo.messageOverlayInfo)
+            is NClusterInfo -> overlayController.saveOverlay(
+                marker,
+                data.markerInfo.messageOverlayInfo
+            )
         }
         return marker
     }
@@ -271,10 +278,26 @@ internal class ClusteringController(
         }
     }
 
+    fun dispose() {
+        if (::clusterer.isInitialized) {
+            clusterer.map = null
+            clusterer.clear()
+        }
+        // strict remove reference (callback remove, if needed)
+//        val builder = ComplexBuilder<NClusterableMarkerInfo>()
+//        clusterer = builder.build()
+//        clusterer.map = naverMap
+//        clusterer.map = null
+//        clusterer.clear()
+
+        clusterableMarkers.clear()
+    }
+
     // --- extension functions ---
     private fun ComplexBuilder<NClusterableMarkerInfo>.applyEnableZoomLevel(range: NRange<Int>): ComplexBuilder<NClusterableMarkerInfo> {
         val min = range.min ?: MINIMUM_ZOOM
         val max = range.max ?: MAXIMUM_ZOOM
-        return minClusteringZoom(min).maxClusteringZoom(max).minIndexingZoom(min).maxIndexingZoom(max)
+        return minClusteringZoom(min).maxClusteringZoom(max).minIndexingZoom(min)
+            .maxIndexingZoom(max)
     }
 }

--- a/ios/Classes/controller/NaverMapController.swift
+++ b/ios/Classes/controller/NaverMapController.swift
@@ -249,6 +249,7 @@ internal class NaverMapController: NaverMapControlSender, NaverMapControlHandler
     
     func removeChannel() {
         channel.setMethodCallHandler(nil)
+        clusteringController.dispose()
         overlayController.removeChannel()
     }
 }

--- a/ios/Classes/controller/clustering/ClusteringController.swift
+++ b/ios/Classes/controller/clustering/ClusteringController.swift
@@ -17,8 +17,12 @@ internal class ClusteringController: NMCDefaultClusterMarkerUpdater, NMCThreshol
     
     private var clusterableMarkers: [NClusterableMarkerInfo: NClusterableMarker] = [:]
     private var mergedScreenDistanceCacheArray: [Double] = Array(repeating: NMC_DEFAULT_SCREEN_DISTANCE, count: 24) // idx: zoom, distance
-    private lazy var clusterMarkerUpdate = ClusterMarkerUpdater(callback: self.onClusterMarkerUpdate)
-    private lazy var clusterableMarkerUpdate = ClusterableMarkerUpdater(callback: self.onClusterableMarkerUpdate)
+    private lazy var clusterMarkerUpdate = ClusterMarkerUpdater(callback: { [weak self] info, marker in
+        self?.onClusterMarkerUpdate(info, marker)
+    })
+    private lazy var clusterableMarkerUpdate = ClusterableMarkerUpdater(callback: { [weak self] info, marker in
+        self?.onClusterableMarkerUpdate(info, marker)
+    })
     
     func updateClusterOptions(_ options: NaverMapClusterOptions) {
         clusterOptions = options
@@ -156,11 +160,15 @@ internal class ClusteringController: NMCDefaultClusterMarkerUpdater, NMCThreshol
         }
     }
     
-    deinit {
+    func dispose() {
         clusterer?.mapView = nil
         clusterer?.clear()
         clusterer = nil
         clusterableMarkers.removeAll()
+    }
+    
+    deinit {
+        dispose()
     }
 }
 


### PR DESCRIPTION
## Abstract

`NaverMap` 위젯을 위젯트리에서 삭제하는 경우에, 일부 오브젝트가 해제되지 않는 현상 (Memory Leak)

기존 코드의 동작에 대한 영향도: 아주 적거나, 없는 것으로 추정. 
*MapView가 dispose시에만 수정된 코드가 실행되며, MapView 별로 객체가 따로 생성되므로(공유하지 않음) 영향도는 별도로 평가되지 않음.

샘플앱을 통한 메모리 릭 실험에서, iOS 플랫폼에서는 아래 결과처럼 메모리 릭이 개선되는 것을 확인하였음. (Android는 재현에 실패함)
`NaverMap` 위젯 약 10회 삽입/삭제 진행. (1200ms 간격, `DoubleMapTestPage` 사용, Profile Mode)

dev/1.3.1 (db8d74eb2e163ab45954d6de2455ac236df02f1f)
min: 513MiB, max 1.46GiB
<img width="259" alt="image" src="https://github.com/user-attachments/assets/024f763f-4319-466d-8746-b49c5d9128fc" />

fix/#275 (c77534cfe9f9b8a93a11ca99968a4d3d7a91347f)
min: 513MiB, max 645MiB
<img width="188" alt="image" src="https://github.com/user-attachments/assets/588d70ca-9ef7-4292-9e83-7a42812b549b" />

