### PR TITLE
Add `NaverMap.onMapLoaded`

### DIFF
--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapControlSender.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapControlSender.kt
@@ -8,6 +8,8 @@ import dev.note11.flutter_naver_map.flutter_naver_map.model.base.NPoint
 internal interface NaverMapControlSender {
     fun onMapReady()
 
+    fun onMapLoaded()
+
     fun onMapTapped(nPoint: NPoint, latLng: LatLng)
 
     fun onSymbolTapped(symbol: Symbol): Boolean?

--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapController.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapController.kt
@@ -273,6 +273,10 @@ internal class NaverMapController(
         channel.invokeMethod("onMapReady", null)
     }
 
+    override fun onMapLoaded() {
+        channel.invokeMethod("onMapLoaded", null)
+    }
+
     override fun onMapTapped(nPoint: NPoint, latLng: LatLng) {
         channel.invokeMethod(
             "onMapTapped", mapOf(

--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/view/NaverMapView.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/view/NaverMapView.kt
@@ -65,7 +65,7 @@ internal class NaverMapView(
     private fun onMapReady() {
         initializeMapController()
         setLocationSource()
-        setMapTapListener()
+        setMapEventListeners()
 
         mapView.onCreate(null)
         naverMapControlSender.onMapReady()
@@ -89,7 +89,7 @@ internal class NaverMapView(
         naverMap.locationSource = NLocationSource(activity)
     }
 
-    private fun setMapTapListener() {
+    private fun setMapEventListeners() {
         isListenerRegistered = true
         naverMap.run {
             setOnMapClickListener { pointFPx, latLng ->
@@ -102,10 +102,11 @@ internal class NaverMapView(
             addOnCameraChangeListener(naverMapControlSender::onCameraChange)
             addOnCameraIdleListener(naverMapControlSender::onCameraIdle)
             addOnIndoorSelectionChangeListener(naverMapControlSender::onSelectedIndoorChanged)
+            addOnLoadListener(naverMapControlSender::onMapLoaded)
         }
     }
 
-    private fun removeMapTapListener() {
+    private fun removeMapEventListeners() {
         if (isListenerRegistered) {
             naverMap.run {
                 onMapClickListener = null
@@ -113,6 +114,7 @@ internal class NaverMapView(
                 removeOnCameraChangeListener(naverMapControlSender::onCameraChange)
                 removeOnCameraIdleListener(naverMapControlSender::onCameraIdle)
                 removeOnIndoorSelectionChangeListener(naverMapControlSender::onSelectedIndoorChanged)
+                removeOnLoadListener(naverMapControlSender::onMapLoaded)
             }
         }
     }
@@ -121,7 +123,7 @@ internal class NaverMapView(
 
     override fun dispose() {
         unRegisterLifecycleCallback()
-        removeMapTapListener()
+        removeMapEventListeners()
 
         mapView.run {
             onPause()
@@ -180,6 +182,7 @@ internal class NaverMapView(
 
     override fun onConfigurationChanged(newConfig: Configuration) {}
 
+    @Deprecated("Deprecated in Java")
     override fun onLowMemory() {
         mapView.onLowMemory()
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -90,6 +90,7 @@ class _FNMapPageState extends State<FNMapPage> {
                 haloColor: Colors.blueAccent));
           }),
       onMapReady: onMapReady,
+      onMapLoaded: onMapLoaded,
       onMapTapped: onMapTapped,
       onSymbolTapped: onSymbolTapped,
       onCameraChange: onCameraChange,
@@ -103,6 +104,13 @@ class _FNMapPageState extends State<FNMapPage> {
   void onMapReady(NaverMapController controller) {
     mapController = controller;
     GetIt.I.registerSingleton(controller);
+  }
+
+  void onMapLoaded() {
+    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+      content: Text("onMapLoaded"),
+      backgroundColor: Colors.black87,
+    ));
   }
 
   void onMapTapped(NPoint point, NLatLng latLng) async {

--- a/ios/Classes/controller/NaverMapControlSender.swift
+++ b/ios/Classes/controller/NaverMapControlSender.swift
@@ -2,6 +2,8 @@ import NMapsMap
 
 internal protocol NaverMapControlSender : AnyObject {
     func onMapReady()
+    
+    func onMapLoaded()
 
     func onMapTapped(nPoint: NPoint, latLng: NMGLatLng)
 

--- a/ios/Classes/controller/NaverMapController.swift
+++ b/ios/Classes/controller/NaverMapController.swift
@@ -213,6 +213,10 @@ internal class NaverMapController: NaverMapControlSender, NaverMapControlHandler
         channel.invokeMethod("onMapReady", arguments: nil)
     }
     
+    func onMapLoaded() {
+        channel.invokeMethod("onMapLoaded", arguments: nil)
+    }
+    
     func onMapTapped(nPoint: NPoint, latLng: NMGLatLng) {
         channel.invokeMethod("onMapTapped", arguments: [
             "nPoint": nPoint.toMessageable(),

--- a/ios/Classes/view/NaverMapViewEventDelegate.swift
+++ b/ios/Classes/view/NaverMapViewEventDelegate.swift
@@ -1,6 +1,6 @@
 import NMapsMap
 
-internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMFMapViewCameraDelegate, NMFIndoorSelectionDelegate {
+internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMFMapViewCameraDelegate, NMFIndoorSelectionDelegate, NMFMapViewLoadDelegate {
     private weak var sender: NaverMapControlSender?
 
     private let initializeConsumeSymbolTapEvents: Bool
@@ -40,16 +40,22 @@ internal class NaverMapViewEventDelegate: NSObject, NMFMapViewTouchDelegate, NMF
     func indoorSelectionDidChanged(_ indoorSelection: NMFIndoorSelection?) {
         sender?.onSelectedIndoorChanged(selectedIndoor: indoorSelection)
     }
+    
+    func mapViewDidFinishLoadingMap(_ mapView: NMFMapView) {
+        sender?.onMapLoaded()
+    }
 
     func registerDelegates(mapView: NMFMapView) {
         mapView.touchDelegate = self
         mapView.addCameraDelegate(delegate: self)
         mapView.addIndoorSelectionDelegate(delegate: self)
+        mapView.addLoadDelegate(delegate: self)
     }
 
     func unregisterDelegates(mapView: NMFMapView) {
         mapView.touchDelegate = nil
         mapView.removeCameraDelegate(delegate: self)
         mapView.removeIndoorSelectionDelegate(delegate: self)
+        mapView.removeLoadDelegate(delegate: self)
     }
 }

--- a/lib/src/controller/map/handler.dart
+++ b/lib/src/controller/map/handler.dart
@@ -3,6 +3,8 @@ part of "../../../flutter_naver_map.dart";
 mixin _NaverMapControlHandler {
   void onMapReady();
 
+  void onMapLoaded();
+
   void onMapTapped(NPoint point, NLatLng latLng);
 
   void onSymbolTapped(NSymbolInfo symbol);
@@ -23,6 +25,9 @@ mixin _NaverMapControlHandler {
     switch (call.method) {
       case "onMapReady":
         onMapReady();
+        break;
+      case "onMapLoaded":
+        onMapLoaded();
         break;
       case "onMapTapped":
         final args = call.arguments;

--- a/lib/src/widget/map_widget.dart
+++ b/lib/src/widget/map_widget.dart
@@ -29,10 +29,19 @@ class NaverMap extends StatefulWidget {
     --- Events ---
   */
 
-  /// 지도가 조작할 수 있는 첫 시점에 실행 되는 함수입니다.
+  /// 지도를 조작할 수 있는 첫 시점에 실행 되는 함수입니다.
+  ///
   /// 위젯 첫 빌드 시에 한 번만 실행 됩니다.
+  ///
   /// 이 콜백을 통해, [NaverMapController]를 매개변수로 얻을 수 있습니다.
   final void Function(NaverMapController controller)? onMapReady;
+
+  /// 지도의 데이터가 모두 로딩되어 최초로 화면에 나타난 후에 실행되는 함수입니다.
+  ///
+  /// 데이터가 모두 로드되어야 실행되므로, [onMapReady] 이후에 한번만 실행됩니다.
+  ///
+  /// 네트워크 속도가 느리거나, 연결에 실패한 경우에는 실행되지 않을 수 있음을 유의해주세요.
+  final void Function()? onMapLoaded;
 
   /// 지도가 사용자에 의해 터치 되었을 때 실행 되는 함수입니다.
   ///
@@ -71,6 +80,7 @@ class NaverMap extends StatefulWidget {
     this.clusterOptions = const NaverMapClusteringOptions(),
     this.forceGesture = false,
     this.onMapReady,
+    this.onMapLoaded,
     this.onMapTapped,
     this.onSymbolTapped,
     this.onCameraChange,
@@ -201,6 +211,9 @@ class _NaverMapState extends State<NaverMap>
       widget.onMapReady?.call(controller);
     });
   }
+
+  @override
+  void onMapLoaded() => widget.onMapLoaded?.call();
 
   @override
   void onMapTapped(NPoint point, NLatLng latLng) =>


### PR DESCRIPTION
## Abstraction

add `onMapLoaded` Event listener on `NaverMap` widget as argument callback.

## Test

tested with real device:
- Android: Galaxy S23 Ultra (Android 15, 1: 400Kbps limit speed, 2: 470Mbps full speed)
- iOS: iPhone 16 Pro (iOS 18.4, 1: 500Kbps limit speed, 2: 700Mbps full speed)


