### PR TITLE
MissingPluginException(No implementation found for flutter_naver_map_overlay) 이슈 수정 건.

### DIFF
--- a/lib/src/controller/map/controller.dart
+++ b/lib/src/controller/map/controller.dart
@@ -268,8 +268,8 @@ class _NaverMapControllerImpl
   @override
   void dispose() {
     myLocationTracker._stopTracking();
-    overlayController.disposeChannel();
     _nowCameraPositionStreamController.close();
     _trackingModeStreamController.close();
+    overlayController.disposeChannel();
   }
 }

--- a/lib/src/messaging/channel_wrapper.dart
+++ b/lib/src/messaging/channel_wrapper.dart
@@ -20,6 +20,7 @@ mixin NChannelWrapper {
 
   void disposeChannel() {
     if (isChannelInitialized) channel.setMethodCallHandler(null);
+    isChannelInitialized = false;
   }
 
   Future<T?> invokeMethod<T>(String funcName, [NMessageable? arg]) {

--- a/lib/src/type/map/overlay/overlay/overlay_sender.dart
+++ b/lib/src/type/map/overlay/overlay/overlay_sender.dart
@@ -21,6 +21,7 @@ mixin _NOverlaySender {
     dynamic lastValue;
 
     for (final overlayController in _overlayControllers) {
+      if (!overlayController.isChannelInitialized) continue;
       lastValue = await overlayController.invokeMethod(query, messageable);
     }
 


### PR DESCRIPTION
## 원인 분석
- setLocationTrackingMode(follow) 호출 시 heading/location 스트림 구독이 시작되는데,
dispose 시 타이밍 이슈로 채널이 먼저 해제된 후에도 스트림 콜백이 실행되고 있습니다.

## 수정 내용
- NChannelWrapper.disposeChannel() — 채널 상태 플래그 관리
disposeChannel() 호출 시 isChannelInitialized = false로 설정

- _NOverlaySender._send() / _set() — dispose 후 호출 방어
overlayController.isChannelInitialized 체크 후 해제된 채널은 skip

- _NaverMapControllerImpl.dispose() — dispose 순서 변경
스트림을 먼저 닫아 콜백 유입을 차단한 뒤, 마지막에 채널을 해제하도록


## 연결된 이슈
#359 

## 테스트 환경
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, 3.38.5, on macOS 26.0 25A5351b darwin-arm64, locale
    en-KR)
[✓] Android toolchain - develop for Android devices (Android SDK version 36.1.0)
[✓] Xcode - develop for iOS and macOS (Xcode 26.0)
[✓] Chrome - develop for the web
[✓] Connected device (4 available)
[✓] Network resources

Flutter_naver_map: v1.4.4

## Demo
- 테스트 버튼을 누르면 새로운 NaverMap PlaformView를 띄우고 뒤로가기 후 다시 진입 계속 반복 테스트 진행했습니다.

[ISSUED CASE]

https://github.com/user-attachments/assets/bc1e2906-3bfb-4c2d-96a9-dd50078e5ba8


[EXPECTED CASE]

https://github.com/user-attachments/assets/21a3677e-c2a2-4536-9400-bb3f18c80d65

