### PR TITLE
fix: resolve NClusterableMarker flickering and crash on delete (#349)

### DIFF
--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapController.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/NaverMapController.kt
@@ -208,7 +208,18 @@ internal class NaverMapController(
                 clusteringController.deleteClusterableMarker(overlayInfo)
             }
 
-            else -> overlayController.deleteOverlay(overlayInfo)
+            else -> {
+                if (overlayController.hasOverlay(overlayInfo)) {
+                    overlayController.deleteOverlay(overlayInfo)
+                } else {
+                    // fallback: marker may have been added as clusterable marker
+                    try {
+                        clusteringController.deleteClusterableMarker(overlayInfo)
+                    } catch (_: Exception) {
+                        // already removed by clustering SDK
+                    }
+                }
+            }
         }
         onSuccess()
     }

--- a/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/clustering/ClusteringController.kt
+++ b/android/src/main/kotlin/dev/note11/flutter_naver_map/flutter_naver_map/controller/clustering/ClusteringController.kt
@@ -97,7 +97,6 @@ internal class ClusteringController(
         val markersWithTag: Map<NClusterableMarkerInfo, NClusterableMarker> =
             markers.associateBy { it.info }
         clusterer.addAll(markersWithTag)
-        updateClusterer()
         clusterableMarkers.putAll(markersWithTag)
     }
 

--- a/ios/flutter_naver_map/Sources/flutter_naver_map/controller/NaverMapController.swift
+++ b/ios/flutter_naver_map/Sources/flutter_naver_map/controller/NaverMapController.swift
@@ -154,7 +154,13 @@ internal class NaverMapController: NaverMapControlSender, NaverMapControlHandler
     func deleteOverlay(overlayInfo: NOverlayInfo, onSuccess: @escaping (Any?) -> ()) {
         switch overlayInfo.type {
         case .clusterableMarker: clusteringController.deleteClusterableMarker(overlayInfo)
-        default: overlayController.deleteOverlay(info: overlayInfo)
+        default:
+            if overlayController.hasOverlay(info: overlayInfo) {
+                overlayController.deleteOverlay(info: overlayInfo)
+            } else {
+                // fallback: marker may have been added as clusterable marker
+                clusteringController.deleteClusterableMarker(overlayInfo)
+            }
         }
         onSuccess(nil)
     }

--- a/ios/flutter_naver_map/Sources/flutter_naver_map/controller/clustering/ClusteringController.swift
+++ b/ios/flutter_naver_map/Sources/flutter_naver_map/controller/clustering/ClusteringController.swift
@@ -67,7 +67,6 @@ internal class ClusteringController: NMCDefaultClusterMarkerUpdater, NMCThreshol
         = Dictionary(uniqueKeysWithValues: markers.map { ($0.clusterInfo, $0) })
         clusterer?.addAll(markersWithTag)
         clusterableMarkers.merge(markersWithTag, uniquingKeysWith: { $1 })
-        updateClusterer()
     }
     
     func deleteClusterableMarker(_ overlayInfo: NOverlayInfo) {

--- a/lib/src/controller/map/controller.dart
+++ b/lib/src/controller/map/controller.dart
@@ -201,7 +201,11 @@ class _NaverMapControllerImpl
   @override
   Future<void> deleteOverlay(NOverlayInfo info) async {
     assert(info.type != NOverlayType.locationOverlay);
-    await invokeMethod("deleteOverlay", info);
+    try {
+      await invokeMethod("deleteOverlay", info);
+    } on PlatformException catch (_) {
+      // overlay may have already been removed by the native clustering SDK
+    }
     overlayController.deleteWithInfo(info);
   }
 

--- a/lib/src/controller/overlay/overlay_controller_impl.dart
+++ b/lib/src/controller/overlay/overlay_controller_impl.dart
@@ -46,10 +46,8 @@ class _NOverlayControllerImpl extends _NOverlayController with NChannelWrapper {
 
   @override
   void deleteWithInfo(NOverlayInfo info) {
-    final helper = overlayHandleAndRemoveHelperMap[info];
-    assert(helper != null, "Not Added or Already Deleted this overlay : $info");
+    final helper = overlayHandleAndRemoveHelperMap.remove(info);
     helper?.remover.call(viewId);
-    overlayHandleAndRemoveHelperMap.remove(info);
   }
 
   @override


### PR DESCRIPTION
## Summary

- `addClusterableMarkerAll`에서 `updateClusterer()` 호출 제거 → `clusterer.map = null; clusterer.map = naverMap` 패턴으로 인한 마커 깜빡임 해결
- Dart `deleteWithInfo`에서 assert 제거 → 클러스터링 SDK가 이미 삭제한 오버레이에 대해 graceful 처리
- Dart `deleteOverlay`에서 `PlatformException` catch → 네이티브에서 이미 삭제된 오버레이 에러 방지
- 네이티브 `deleteOverlay`에 타입 fallback 추가 → `NOverlayType.marker`로 삭제 시 일반 오버레이 컨트롤러에 없으면 클러스터링 컨트롤러에서 탐색

Fixes https://github.com/note11g/flutter_naver_map/issues/349

## Test plan

- [ ] `NClusterableMarker`로 마커 추가/삭제 반복 시 깜빡임 없는지 확인
- [ ] 마커 교체(새 마커 추가 + 기존 마커 삭제) 시 assertion/PlatformException 발생하지 않는지 확인
- [ ] 클러스터링 정상 동작 확인 (줌 레벨 변경 시 마커 합쳐지고 풀리는지)
- [ ] `addAll`만으로 새 마커가 화면에 정상 표시되는지 확인 (Fix 3 검증)
- [ ] 일반 `NMarker`가 기존과 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)